### PR TITLE
Load the model's template class via the same classloader that loaded the model class

### DIFF
--- a/runtime/src/main/java/com/fizzed/rocker/runtime/DefaultRockerBootstrap.java
+++ b/runtime/src/main/java/com/fizzed/rocker/runtime/DefaultRockerBootstrap.java
@@ -49,7 +49,7 @@ public class DefaultRockerBootstrap implements RockerBootstrap {
     @Override
     public DefaultRockerTemplate template(Class modelType, DefaultRockerModel model) throws RenderingException {
         
-        return buildTemplate(modelType, model, DefaultRockerBootstrap.class.getClassLoader());
+        return buildTemplate(modelType, model, modelType.getClassLoader());
 
     }
     


### PR DESCRIPTION
The reformatting is due to IntelliJ's auto formatting which I do reflexively. Let me know if that's a problem and I'll trim things down.