### PR TITLE
Potential (i.e. untested) fix for issue #17.

### DIFF
--- a/compiler/src/main/java/com/fizzed/rocker/compiler/TemplateParser.java
+++ b/compiler/src/main/java/com/fizzed/rocker/compiler/TemplateParser.java
@@ -519,6 +519,10 @@ public class TemplateParser {
             // chomp off parenthese
             statement = statement.substring(1, statement.length() - 1);
             
+            // fix for issue #17
+            // remove leading and trailing spaces (might result in empty string, which is ok)
+            statement = statement.trim();
+            
             try {
                 List<JavaVariable> args = JavaVariable.parseList(statement);
                 


### PR DESCRIPTION
- argument statement string is trimmed down, possibly resulting in an
empty string which should be ok for proper no-argument handling.