### PR TITLE
Empty args multiline

### DIFF
--- a/compiler/src/main/java/com/fizzed/rocker/compiler/TemplateParser.java
+++ b/compiler/src/main/java/com/fizzed/rocker/compiler/TemplateParser.java
@@ -15,21 +15,7 @@
  */
 package com.fizzed.rocker.compiler;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
-
-import org.antlr.v4.runtime.ANTLRFileStream;
-import org.antlr.v4.runtime.ANTLRInputStream;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.misc.Interval;
-import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.fizzed.rocker.runtime.ParserException;
 import com.fizzed.rocker.ContentType;
 import com.fizzed.rocker.antlr4.RockerLexer;
 import com.fizzed.rocker.antlr4.RockerParser;
@@ -58,7 +44,19 @@ import com.fizzed.rocker.model.TemplateUnit;
 import com.fizzed.rocker.model.ValueClosureBegin;
 import com.fizzed.rocker.model.ValueClosureEnd;
 import com.fizzed.rocker.model.ValueExpression;
-import com.fizzed.rocker.runtime.ParserException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.antlr.v4.runtime.ANTLRFileStream;
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *

--- a/compiler/src/main/java/com/fizzed/rocker/compiler/TemplateParser.java
+++ b/compiler/src/main/java/com/fizzed/rocker/compiler/TemplateParser.java
@@ -15,7 +15,21 @@
  */
 package com.fizzed.rocker.compiler;
 
-import com.fizzed.rocker.runtime.ParserException;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.antlr.v4.runtime.ANTLRFileStream;
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fizzed.rocker.ContentType;
 import com.fizzed.rocker.antlr4.RockerLexer;
 import com.fizzed.rocker.antlr4.RockerParser;
@@ -44,19 +58,7 @@ import com.fizzed.rocker.model.TemplateUnit;
 import com.fizzed.rocker.model.ValueClosureBegin;
 import com.fizzed.rocker.model.ValueClosureEnd;
 import com.fizzed.rocker.model.ValueExpression;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
-import org.antlr.v4.runtime.ANTLRFileStream;
-import org.antlr.v4.runtime.ANTLRInputStream;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.misc.Interval;
-import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.fizzed.rocker.runtime.ParserException;
 
 /**
  *
@@ -521,7 +523,8 @@ public class TemplateParser {
             
             // fix for issue #17
             // remove leading and trailing spaces (might result in empty string, which is ok)
-            statement = statement.trim();
+            // supports empty argument lists spanning over multiple lines
+            statement = statement.replaceAll("\\s+", " ").trim();
             
             try {
                 List<JavaVariable> args = JavaVariable.parseList(statement);

--- a/java6test/src/test/java/com/fizzed/rocker/RockerTest.java
+++ b/java6test/src/test/java/com/fizzed/rocker/RockerTest.java
@@ -66,5 +66,27 @@ public class RockerTest {
         BindableRockerModel template = Rocker.template("rocker/Args.rocker.html");
         template.bind("s", 1);
     }
+
+    @Test
+    public void templateWithEmptyArgumentsNoSpaces() throws Exception {
+        BindableRockerModel template = Rocker.template("rocker/ArgsEmptyNoSpaces.rocker.html");
+        String out = template.render().toString().trim();
+        Assert.assertEquals("Test", out);
+    }
     
+    @Test
+    public void templateWithEmptyArgumentsWithSpaces() throws Exception {
+        BindableRockerModel template = Rocker.template("rocker/ArgsEmptyWithSpaces.rocker.html");
+        String out = template.render().toString().trim();
+        Assert.assertEquals("Test", out);
+    }
+    
+    @Test
+    public void templateWithEmptyArgumentsWithSpacesMultiline() throws Exception {
+        BindableRockerModel template = Rocker.template("rocker/ArgsEmptyWithSpacesMultiline.rocker.html");
+        String out = template.render().toString().trim();
+        Assert.assertEquals("Test", out);
+    }
+    
+
 }

--- a/java6test/src/test/java/rocker/ArgsEmptyNoSpaces.rocker.html
+++ b/java6test/src/test/java/rocker/ArgsEmptyNoSpaces.rocker.html
@@ -1,0 +1,5 @@
+@*
+ * Test for an empty argument list (without spaces)
+ *@
+@args()
+Test

--- a/java6test/src/test/java/rocker/ArgsEmptyWithSpaces.rocker.html
+++ b/java6test/src/test/java/rocker/ArgsEmptyWithSpaces.rocker.html
@@ -1,0 +1,5 @@
+@*
+ * Test for an empty argument list (without spaces)
+ *@
+@args(  )
+Test

--- a/java6test/src/test/java/rocker/ArgsEmptyWithSpacesMultiline.rocker.html
+++ b/java6test/src/test/java/rocker/ArgsEmptyWithSpacesMultiline.rocker.html
@@ -1,0 +1,6 @@
+@*
+ * Test for an empty argument list (without spaces)
+ *@
+@args( 
+	 )
+Test


### PR DESCRIPTION
The previous fix #18 didn't support empty argument lists spanning over multiple lines.
Added test cases for empty arguments.
