### PR TITLE
Added option "postProcessing".

### DIFF
--- a/compiler/src/main/java/com/fizzed/rocker/compiler/RockerOptions.java
+++ b/compiler/src/main/java/com/fizzed/rocker/compiler/RockerOptions.java
@@ -77,7 +77,9 @@ public class RockerOptions {
         options.extendsModelClass = this.extendsModelClass;
         options.targetCharset = this.targetCharset;
         options.optimize = this.optimize;
-        options.postProcessing = Arrays.copyOf(this.postProcessing, this.postProcessing.length);
+        // do not copy post-processor class names from global configuration.
+        // these need to be kept separate from per-template configurations.
+        options.postProcessing = new String[0];
         return options;
     }
 

--- a/compiler/src/main/java/com/fizzed/rocker/compiler/RockerOptions.java
+++ b/compiler/src/main/java/com/fizzed/rocker/compiler/RockerOptions.java
@@ -20,7 +20,9 @@ import com.fizzed.rocker.ContentType;
 import com.fizzed.rocker.model.JavaVersion;
 import com.fizzed.rocker.model.Option;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.StringTokenizer;
 
 /**
  *
@@ -35,6 +37,7 @@ public class RockerOptions {
     static public final String EXTENDS_MODEL_CLASS = "extendsModelClass";
     static public final String TARGET_CHARSET = "targetCharset";
     static public final String OPTIMIZE = "optimize";
+    static public final String POST_PROCESSING = "postProcessing";
     
     // generated source compatiblity
     private JavaVersion javaVersion;
@@ -51,6 +54,8 @@ public class RockerOptions {
     private String targetCharset;
     // templates optimized for production
     private Boolean optimize;
+    // names of classes to be used for post-processing the model in order of appearance
+    private String[] postProcessing;
     
     public RockerOptions() {
         this.javaVersion = JavaVersion.v1_8;
@@ -60,6 +65,7 @@ public class RockerOptions {
         this.extendsModelClass = com.fizzed.rocker.runtime.DefaultRockerModel.class.getName();
         this.targetCharset = "UTF-8";
         this.optimize = Boolean.FALSE;
+        this.postProcessing = new String[0];
     }
     
     public RockerOptions copy() {
@@ -71,6 +77,7 @@ public class RockerOptions {
         options.extendsModelClass = this.extendsModelClass;
         options.targetCharset = this.targetCharset;
         options.optimize = this.optimize;
+        options.postProcessing = Arrays.copyOf(this.postProcessing, this.postProcessing.length);
         return options;
     }
 
@@ -158,6 +165,14 @@ public class RockerOptions {
         this.optimize = optimize;
     }
 
+    public String[] getPostProcessing() {
+    	return postProcessing;
+    }
+    
+    public void setPostProcessing( String[] postProcessing ) {
+        this.postProcessing = postProcessing;
+    }
+
     public void set(String name, String value) throws TokenException {
         String optionName = name.trim();
         String optionValue = value.trim();
@@ -184,6 +199,9 @@ public class RockerOptions {
             case OPTIMIZE:
                 this.setOptimize(parseBoolean(optionValue));
                 break;
+            case POST_PROCESSING:
+            	this.setPostProcessing(parseStringArrayFromList(optionValue));
+            	break;
             default:
                 throw new TokenException("Invalid option (" + optionName + ") is not a property)");
         }
@@ -239,6 +257,26 @@ public class RockerOptions {
         else {
             throw new TokenException("Unparseable boolean");
         }
+    }
+    
+    /**
+     * Create an array of sub-strings from a given comma-separated string.
+     * The contents of each string in the returned array will be trimmed of leading and trailing spaces.
+     * @param value the original string, containing individual comma-separated tokens
+     * @return an array of 
+     * @throws TokenException
+     */
+    private String[] parseStringArrayFromList( String value ) throws TokenException {
+        if ( value == null ) {
+            throw new TokenException("List of strings cannot be null");
+        }
+        StringTokenizer st = new StringTokenizer(value, ",");
+        String[] tokens = new String[st.countTokens()];
+        int i = 0;
+        while ( st.hasMoreTokens() ) {
+            tokens[i++] = st.nextToken().trim(); 
+        }
+        return tokens;
     }
 
 }

--- a/compiler/src/main/java/com/fizzed/rocker/model/PostProcessorException.java
+++ b/compiler/src/main/java/com/fizzed/rocker/model/PostProcessorException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Fendler Consulting cc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fizzed.rocker.model;
+
+/**
+ *
+ * @author jensfendler
+ */
+public class PostProcessorException extends Exception {
+
+    /**
+     * Create a new instance of a {@link PostProcessorException} with the given
+     * message.
+     *
+     * @param message the error message
+     */
+    public PostProcessorException(String message) {
+        super(message);
+    }
+    
+    /**
+     * Create a new instance of a {@link PostProcessorException} with the given
+     * message and the causing Throwable.
+     *
+     * @param message the error message
+     * @param cause the {@link Throwable} which caused this exception
+     */
+    public PostProcessorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+}

--- a/compiler/src/main/java/com/fizzed/rocker/model/TemplateModelPostProcessor.java
+++ b/compiler/src/main/java/com/fizzed/rocker/model/TemplateModelPostProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Fendler Consulting cc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fizzed.rocker.model;
+
+import com.fizzed.rocker.compiler.JavaGenerator;
+import com.fizzed.rocker.compiler.RockerOptions;
+
+/**
+ * Classes implementing the {@link TemplateModelPostProcessor} interface can 
+ * be used as post-processors of {@link TemplateModel}s.
+ * 
+ * To activate such post-processing, Rocker templates must be provided with
+ * the "postProcessing" option (@see {@link RockerOptions#POST_PROCESSING}), 
+ * containing a comma-separated list of class names implementing this interface.
+ * 
+ * The {@link JavaGenerator} then calls each given post-processor with the 
+ * {@link TemplateModel} as argument immediately before the resulting template
+ * Java code is created. 
+ * 
+ * @author jensfendler
+ */
+public interface TemplateModelPostProcessor {
+
+    /**
+     * Performs any post-processing on the given {@link TemplateModel} as defined 
+     * by the implementing class. 
+     * Only the returned instance shall be used further by the caller. Implementing
+     * classes may choose to return the provided instance, or create a completely new 
+     * instance for further processing.
+     *   
+     * @param templateModel the original template model (which might have already been 
+     *     processed by previous {@link TemplateModelPostProcessor}s.
+     * @param ppIndex the index (starting from 0) of the post-processor as it appears in
+     *     the list of given post-processor class names.  
+     * @return the resulting {@link TemplateModel} which shall be used for further 
+     *     processing by following post-processors, or finally by the {@link JavaGenerator}.
+     */
+    public TemplateModel process( TemplateModel templateModel, int ppIndex ) throws PostProcessorException;
+    
+}

--- a/compiler/src/main/java/com/fizzed/rocker/processor/LoggingProcessor.java
+++ b/compiler/src/main/java/com/fizzed/rocker/processor/LoggingProcessor.java
@@ -37,7 +37,7 @@ public class LoggingProcessor implements TemplateModelPostProcessor {
      */
     @Override
     public TemplateModel process(TemplateModel templateModel, int ppIndex) throws PostProcessorException {
-        log.info("Template {} being post-processed by {} at index {}.", templateModel.getName(), getClass().getSimpleName(), ppIndex );
+        log.debug("Template {} being post-processed by {} at index {}.", templateModel.getName(), getClass().getSimpleName(), ppIndex );
         return templateModel;
     }
 

--- a/compiler/src/main/java/com/fizzed/rocker/processor/LoggingProcessor.java
+++ b/compiler/src/main/java/com/fizzed/rocker/processor/LoggingProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 Fendler Consulting cc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fizzed.rocker.processor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fizzed.rocker.model.PostProcessorException;
+import com.fizzed.rocker.model.TemplateModel;
+import com.fizzed.rocker.model.TemplateModelPostProcessor;
+
+/**
+ * This post-processor does not modify the model, but simply does some logging. 
+ * It is intended for testing purposes only.
+ *  
+ * @author jensfendler
+ */
+public class LoggingProcessor implements TemplateModelPostProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingProcessor.class);
+    
+    /**
+     * @see com.fizzed.rocker.model.TemplateModelPostProcessor#process(com.fizzed.rocker.model.TemplateModel, int)
+     */
+    @Override
+    public TemplateModel process(TemplateModel templateModel, int ppIndex) throws PostProcessorException {
+        log.info("Template {} being post-processed by {} at index {}.", templateModel.getName(), getClass().getSimpleName(), ppIndex );
+        return templateModel;
+    }
+
+}

--- a/compiler/src/main/java/com/fizzed/rocker/processor/WhitespaceRemovalProcessor.java
+++ b/compiler/src/main/java/com/fizzed/rocker/processor/WhitespaceRemovalProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 Fendler Consulting cc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.fizzed.rocker.processor;
+
+import com.fizzed.rocker.model.PlainText;
+import com.fizzed.rocker.model.PostProcessorException;
+import com.fizzed.rocker.model.TemplateModel;
+import com.fizzed.rocker.model.TemplateModelPostProcessor;
+import com.fizzed.rocker.model.TemplateUnit;
+
+/**
+ * This post-processor reduces the amount of whitespace in static strings.
+ *  
+ * @author jensfendler
+ */
+public class WhitespaceRemovalProcessor implements TemplateModelPostProcessor {
+
+    /**
+     * For whitespace removals: matching one or more new-lines after horizontal spaces (e.g. space, tab),
+     * i.e. at the end of a line. Will be replaced by a single \n.  
+     */
+    private static final String LINE_END = "[ \t]+[\n\r]+";
+    
+    /**
+     * For whitespace removals: matching more than one horizontal whitespace in a single line.
+     * Will be replaced by a single space. 
+     */
+    private static final String IN_LINE = "[ \t]{2,}";
+
+    /**
+     * For whitespace removals: matching one or more horizontal space (e.g. space, tab) after 
+     * one or more new-lines (i.e. at the beginning of a line).
+     * Will be replaced by a single new line.
+     */
+    private static final String LINE_START = "[\n\r]+[ \t]+";
+ 
+    /**
+     * @see com.fizzed.rocker.model.TemplateModelPostProcessor#process(com.fizzed.rocker.model.TemplateModel, int)
+     */
+    @Override
+    public TemplateModel process(TemplateModel templateModel, int ppIndex) throws PostProcessorException {
+        for (int i = 0; i < templateModel.getUnits().size(); i ++) {
+            TemplateUnit tu = templateModel.getUnits().get(i);
+            if (tu instanceof PlainText) {
+                PlainText pt = (PlainText)tu;
+                
+                // create a replacement PlainText unit with reduced whitespace
+                PlainText replacementPt = new PlainText(pt.getSourceRef(), reduceWhitespace(pt.getText()));
+                
+                // replace the unit
+                templateModel.getUnits().add(i, replacementPt);
+                templateModel.getUnits().remove(i+1);
+            }
+        }
+        return templateModel;
+    }
+
+    /**
+     * Replace a given string with a whitespace-reduced variant of itself.
+     * 
+     * @param text original string with whitespaces.
+     * @return the string with multiple occurences of whitespaces reduced to single occurences.
+     */
+    private String reduceWhitespace(String text) {
+        if ( text == null ) {
+            return null;
+        }
+        return text.replaceAll(LINE_END, "\n").replaceAll(LINE_START, "\n").replaceAll(IN_LINE, " ");
+    }
+
+}

--- a/compiler/src/test/java/com/fizzed/rocker/compiler/TemplateParserTest.java
+++ b/compiler/src/test/java/com/fizzed/rocker/compiler/TemplateParserTest.java
@@ -625,4 +625,38 @@ public class TemplateParserTest {
             Assert.assertEquals(1, e.getLineNumber());
         }
     }
+    
+    @Test
+    public void optionPostProcessing1() throws Exception {
+        TemplateParser parser = createParser();
+        File f = findTemplate("rocker/parser/OptionPostProcessing1.rocker.html");
+        
+        TemplateModel model = parser.parse(f);
+        
+        Assert.assertArrayEquals(new String[] {"com.fizzed.rocker.processor.WhitespaceRemovalProcessor", 
+            "com.fizzed.rocker.processor.LoggingProcessor"}, model.getOptions().getPostProcessing());
+    }
+
+    @Test
+    public void optionPostProcessing2() throws Exception {
+        TemplateParser parser = createParser();
+        File f = findTemplate("rocker/parser/OptionPostProcessing2.rocker.html");
+        
+        TemplateModel model = parser.parse(f);
+        
+        Assert.assertArrayEquals(new String[] {"com.fizzed.rocker.processor.WhitespaceRemovalProcessor", 
+            "com.fizzed.rocker.processor.LoggingProcessor"}, model.getOptions().getPostProcessing());
+    }
+
+    @Test
+    public void optionPostProcessing3() throws Exception {
+        TemplateParser parser = createParser();
+        File f = findTemplate("rocker/parser/OptionPostProcessing3.rocker.html");
+        
+        TemplateModel model = parser.parse(f);
+        
+        Assert.assertArrayEquals(new String[] {"com.fizzed.rocker.processor.LoggingProcessor", 
+            "com.fizzed.rocker.processor.WhitespaceRemovalProcessor", 
+            "com.fizzed.rocker.processor.LoggingProcessor"}, model.getOptions().getPostProcessing());
+    }
 }

--- a/compiler/src/test/resources/rocker/parser/OptionPostProcessing1.rocker.html
+++ b/compiler/src/test/resources/rocker/parser/OptionPostProcessing1.rocker.html
@@ -1,0 +1,4 @@
+@* 
+ * test for the "postProcessing" option
+ *@
+@option postProcessing=com.fizzed.rocker.processor.WhitespaceRemovalProcessor,com.fizzed.rocker.processor.LoggingProcessor

--- a/compiler/src/test/resources/rocker/parser/OptionPostProcessing2.rocker.html
+++ b/compiler/src/test/resources/rocker/parser/OptionPostProcessing2.rocker.html
@@ -1,0 +1,4 @@
+@* 
+ * test handling of extra spaces around post-processor class names
+ *@
+@option postProcessing= com.fizzed.rocker.processor.WhitespaceRemovalProcessor,  com.fizzed.rocker.processor.LoggingProcessor 

--- a/compiler/src/test/resources/rocker/parser/OptionPostProcessing3.rocker.html
+++ b/compiler/src/test/resources/rocker/parser/OptionPostProcessing3.rocker.html
@@ -1,0 +1,4 @@
+@* 
+ * test multiple occurences of the same post-processor
+ *@
+@option postProcessing=com.fizzed.rocker.processor.LoggingProcessor,com.fizzed.rocker.processor.WhitespaceRemovalProcessor,com.fizzed.rocker.processor.LoggingProcessor

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -398,6 +398,14 @@ intermediate classes that you'd like all templates to extend. Defaults to ```com
 The target charset for template output.  Defaults to UTF-8.  Accepts any value
 that is supported by Java's standard charsetName.
 
+### Post-Processing of Templates
+
+    @option postProcessing=com.sample.MyTemlateModelPostProcessor
+
+Post-processing of templates allows custom classes to perform compile-time 
+transformation of the model your templates are parsed into before any Java
+code is generated. See the section on Post-Processing below for details.
+
 ## Handling null values
 
 We suggest using the ```Optional``` class either via Google Gauva for Java 6/7
@@ -482,3 +490,54 @@ This will result in rendering
 </body>
 </html>
 ```
+
+## Post-Processing
+
+Rocker supports custom post-processing of the model your templates are parsed into before
+any Java code is actually generated for them.
+Post-processing is a compile-time feature which does not take any dynamic evaluations
+(e.g. method calls within your templates) into account.
+
+To enable post-processing for your templates, either add the postProcessing configuration
+to your pom.xml, and/or specify your post-processors using `@option postProcessing=...`
+
+### Global Setup of Post-Processors with Maven
+Provide a list of Post-Processor class names in your pom.xml to have these processors
+being executed on every one of your models.
+```xml
+    <configuration>
+    	<!-- ... other rocker configuration options -->
+        <postProcessing>
+        	<param>com.fizzed.rocker.processor.LoggingProcessor</param>
+        	<param>com.fizzed.rocker.processor.WhitespaceRemovalProcessor</param>
+        </postProcessing>
+    </configuration>
+</execution>
+```
+
+### Per-Template Setup of Post-Processors with @option
+To setup post-processing for selected templates only, use the following option at the
+beginning of your templates:
+```
+@option postProcessing=com.fizzed.rocker.processor.LoggingProcessor,com.fizzed.rocker.processor.WhitespaceRemovalProcessor
+```
+
+### Order of Execution
+
+If post-processors are setup in both ways (i.e. through pom.xml <b>and</b> with the `@option`
+directive, then the list of post-processors to run on the template will be the concatenation
+of first all post-processors from pom.xml, and then all post-processors from the template.
+
+Post-Processors are guaranteed to always execute in the order in which they were specified. 
+
+### Multiple Calls to the same Processor
+
+The same Post-Processor is allowed to run multiple times on the same template. To further
+support this, each post processor is provided with a 'call index' during execution, which is
+the index (starting with 0) of the active post-processor in the list of all post-processors 
+to run.
+
+However, post-processor instances are currently not reused. A new object is instantiated
+whenever a post-processor is called. If you need to maintain some context between two
+executions of post-processors, you could either use static fields, or amend the template
+model by adding otherwise unused `Unit`s (e.g. `PlainText`).  

--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -508,8 +508,8 @@ being executed on every one of your models.
     <configuration>
     	<!-- ... other rocker configuration options -->
         <postProcessing>
-        	<param>com.fizzed.rocker.processor.LoggingProcessor</param>
-        	<param>com.fizzed.rocker.processor.WhitespaceRemovalProcessor</param>
+            <param>com.fizzed.rocker.processor.LoggingProcessor</param>
+            <param>com.fizzed.rocker.processor.WhitespaceRemovalProcessor</param>
         </postProcessing>
     </configuration>
 </execution>

--- a/java6test/pom.xml
+++ b/java6test/pom.xml
@@ -42,6 +42,9 @@
                             <discardLogicWhitespace>false</discardLogicWhitespace>
                             <addAsTestSources>true</addAsTestSources>
                             <optimize>true</optimize>
+                            <postProcessing>
+                            	<param>com.fizzed.rocker.processor.LoggingProcessor</param>
+                            </postProcessing>
                         </configuration>
                     </execution>
                 </executions>

--- a/java6test/src/test/java/com/fizzed/rocker/compiler/CompiledTemplateTest.java
+++ b/java6test/src/test/java/com/fizzed/rocker/compiler/CompiledTemplateTest.java
@@ -705,5 +705,14 @@ public class CompiledTemplateTest {
         Assert.assertEquals("<h1>Hello Joe!</h1>", html);
     }
     */
-    
+
+    @Test
+    public void postProcessingTest1() throws Exception {
+        String out = rocker.PostProcessing1.template("Test")
+            .render()
+            .toString();
+        
+        Assert.assertEquals("\nPost-Processing Test\n", out);
+    }
+
 }

--- a/java6test/src/test/java/rocker/PostProcessing1.rocker.html
+++ b/java6test/src/test/java/rocker/PostProcessing1.rocker.html
@@ -1,0 +1,9 @@
+@*
+ * Test the post-processing of templates (whitespace removal and logging).
+ *@
+@option postProcessing=com.fizzed.rocker.processor.WhitespaceRemovalProcessor,com.fizzed.rocker.processor.LoggingProcessor
+@args(String s)
+
+
+ 	 Post-Processing @s 	 
+

--- a/maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
+++ b/maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
@@ -83,6 +83,9 @@ public class GenerateMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project}", readonly = true )
     protected MavenProject project;
     
+    @Parameter( property = "rocker.postProcessing", required = false)
+    protected String[] postProcessing;
+    
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (this.skip) {
@@ -146,6 +149,9 @@ public class GenerateMojo extends AbstractMojo {
             }
             if (optimize != null) {
                 jgm.getParser().getConfiguration().getOptions().setOptimize(optimize);
+            }
+            if (postProcessing != null ) {
+            	jgm.getParser().getConfiguration().getOptions().setPostProcessing(postProcessing);
             }
             
             jgm.run();


### PR DESCRIPTION
- This option takes a comma-separated list of class names implementing
the TemplateModelPostProcessor interface.
- Before Java code is generated from templates in JavaGenerator, all
registered post-processors are called on the model, allowing them to
perform transformations on the model before Java code is created.
- Sample processors currently available are WhitespaceRemovalProcessor
and LoggingProcessor.

@jjlauer if this is more or less what you were having in mind, I hope this one is good to go. Let me know if you're not happy with the new package name ("processor"), or anything else (well, I know you will :-)