### PR TITLE
Ignore synthetic fields when reading template fragments.

### DIFF
--- a/runtime/src/main/java/com/fizzed/rocker/runtime/PlainTextUnloadedClassLoader.java
+++ b/runtime/src/main/java/com/fizzed/rocker/runtime/PlainTextUnloadedClassLoader.java
@@ -117,6 +117,10 @@ public class PlainTextUnloadedClassLoader {
         Map<String,byte[]> fields = new HashMap<String,byte[]>();
         
         for (Field field : type.getDeclaredFields()) {
+            if (field.isSynthetic()) {
+                continue;
+            }
+
             field.setAccessible(true);
             
             // field should be static


### PR DESCRIPTION
I hit this when running tests with JaCoCo. It adds synthetic fields to all classes.