### PR TITLE
This creates a class loader that includes the classes from the projec…

### DIFF
--- a/compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
+++ b/compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
@@ -967,7 +967,7 @@ public class JavaGenerator {
         for ( int i = 0; i < postProcessorClassNames.size(); i ++ ) {
             String ppClassName = postProcessorClassNames.get(i);
             try {
-                Class<TemplateModelPostProcessor> ppClass = (Class<TemplateModelPostProcessor>) Class.forName(ppClassName);
+                Class<TemplateModelPostProcessor> ppClass = (Class<TemplateModelPostProcessor>) configuration.getClassLoader().loadClass(ppClassName);
                 TemplateModelPostProcessor postProcessor = ppClass.newInstance();
                 log.debug("Running post-processor {} on template {} at index {}.", postProcessor.getClass().getName(), templateModel.getName(), i );
                 templateModel = postProcessor.process(templateModel, i);

--- a/compiler/src/main/java/com/fizzed/rocker/compiler/RockerConfiguration.java
+++ b/compiler/src/main/java/com/fizzed/rocker/compiler/RockerConfiguration.java
@@ -43,11 +43,13 @@ public class RockerConfiguration {
     private File classDirectory;
     //private File compileDirectory;
     private RockerOptions options;
-    
+    private ClassLoader classLoader;
+
     public RockerConfiguration() {
         this.templateDirectory = new File("src/main/resources/rocker");
         this.outputDirectory = new File("target/generated-sources/rocker");
         this.classDirectory = new File("target/classes");
+        this.classLoader = getClass().getClassLoader();
         //this.compileDirectory = null;
         this.options = new RockerOptions();
         // merge in rocker.conf from classpath
@@ -145,6 +147,14 @@ public class RockerConfiguration {
 
     public void setClassDirectory(File classDirectory) {
         this.classDirectory = classDirectory;
+    }
+
+    public ClassLoader getClassLoader() {
+        return classLoader;
+    }
+
+    public void setClassLoader(ClassLoader classLoader) {
+        this.classLoader = classLoader;
     }
 
     /**


### PR DESCRIPTION
…t one is working on.

It solves a ClassNotFoundException issued from `Class.forName` which would only get
classes pulled in from the Rocker pom rather than your project pom meaning that
post-processors included with Rocker would work, but not post-processors in your project.

I'm not sure that this is a good way to fix the issue, but it means that post-processors in my project are available to use.