### PR TITLE
Swapping Apache HTML escaping for Guava

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -26,6 +26,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
 
         <!-- test -->
         <dependency>

--- a/runtime/src/main/java/com/fizzed/rocker/runtime/HtmlStringify.java
+++ b/runtime/src/main/java/com/fizzed/rocker/runtime/HtmlStringify.java
@@ -15,7 +15,7 @@
  */
 package com.fizzed.rocker.runtime;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import com.google.common.html.HtmlEscapers;
 
 /**
  *
@@ -25,7 +25,7 @@ public class HtmlStringify extends RawStringify {
 
     @Override
     public String s(String str) {
-        return StringEscapeUtils.escapeHtml3(str);
+        return HtmlEscapers.htmlEscaper().escape(str);
     }
 
     @Override


### PR DESCRIPTION
I don't know if you want to bring Guava in as a dependency, but it's significantly faster than the apache escaping.

I ran some tests with the template benchmark linked in the readme, slightly modified (https://github.com/sphogan/template-benchmark/commit/4396c4c4afa80861d4654639cbb0c8a109c6a0b7).

HTML escaping with Guava results in benchmarks that are about 3x faster.  Guava HTML escaping seems to create a performance hit around 5% rather than the 66% hit from Apache.  Using the Apache escaping, Rocker seems to fall behind some of the other template engines in my very limited testing.

One thing to note, Guava's HTML escaping simply deals with `'"&<>` to sanitize HTML (5 characters).  StringEscapeUtils.escapeHtml3 does `"&<>` for basic escaping (4 characters) plus nearly 100 others in `ISO8859_1_ESCAPE` which don't seem related to HTML sanitizing.  I also tried using Apache's `StringEscapeUtils.escapeXml` which does the same 5 characters as Guava without much improvement in speed.

```
HTML Escaped
Benchmark              Mode  Cnt      Score     Error  Units
Handlebars.benchmark  thrpt   50  12440.415 ± 552.966  ops/s
Mustache.benchmark    thrpt   50  13442.148 ± 106.573  ops/s
Pebble.benchmark      thrpt   50  17216.058 ± 295.969  ops/s
Trimou.benchmark      thrpt   50   6269.462 ±  46.882  ops/s

Rocker.benchmark      thrpt   50  27525.912 ± 140.046  ops/s #Guava
Rocker.benchmark      thrpt   50  27663.087 ± 117.968  ops/s #Guava
Rocker.benchmark      thrpt   50  9404.686 ± 65.230  ops/s #Apache
Rocker.benchmark      thrpt   50  9404.179 ± 77.161  ops/s #Apache
Rocker.benchmark      thrpt   50  9680.481 ± 110.028  ops/s #Apache escapeXml
```

```
No Escaping (for comparison)
Benchmark              Mode  Cnt      Score     Error  Units
Handlebars.benchmark  thrpt   50  13846.235 ± 104.330  ops/s
Mustache.benchmark    thrpt   50  15895.397 ± 162.427  ops/s
Pebble.benchmark      thrpt   50  25500.801 ± 407.748  ops/s
Rocker.benchmark      thrpt   50  28927.679 ± 170.489  ops/s
Trimou.benchmark      thrpt   50  16685.004 ± 170.234  ops/s
```