### PR TITLE
Fix issue where usage of variables from the @for

### DIFF
--- a/rocker-test-java6/src/test/java/rocker/ForBlockWithWithBlock.rocker.html
+++ b/rocker-test-java6/src/test/java/rocker/ForBlockWithWithBlock.rocker.html
@@ -1,0 +1,83 @@
+@import java.math.BigDecimal
+@import java.util.List
+@import java.util.Map
+
+@args(List<BigDecimal> list, Map<String,BigDecimal> map)
+
+@*
+ * Collection loop.
+ *@
+@for (BigDecimal value : list) {
+  @with (BigDecimal newObject =	value.stripTrailingZeros()) {
+    Inside with block, the line below didn't compile.
+    @value.toString()
+  }
+  Outside with block is fine: @value.toString()
+}
+
+@*
+ * Collection loop with iterator.
+ *@
+@for ((ForIterator itr, BigDecimal value) : list) {
+  @with (Integer index = itr.index()) {
+    Inside with block, the lines below didn't compile.
+    @itr.index()
+    @itr.first()
+    @itr.last()
+  }
+  Outside with block is fine:
+  @itr.index()
+  @itr.first()
+  @itr.last()
+}
+
+@*
+ * Indexed loop. Disabled for now, since that requires more changes to the generation.
+ * Currently fails.
+@for (int i = 0; i < list.size(); i++) {
+  @with (BigDecimal newObject =	list.get(i)) {
+    Inside with block, the line below didn't compile.
+    @list.get(i)
+  }
+  Outside with block is fine: @list.get(i)
+}
+*@
+
+
+@*
+ * Enhanced map loop (test on key).
+ *@
+@for ((String key, BigDecimal value) : map) {
+  @with (String newObject =	key.toLowerCase()) {
+    Inside with block, the line below didn't compile.
+    @key.toLowerCase()
+  }
+  Outside with block is fine: @key.toLowerCase()
+}
+
+@*
+ * Enhanced map loop (test on value).
+ *@
+@for ((String key, BigDecimal value) : map) {
+  @with (BigDecimal newObject =	value.stripTrailingZeros()) {
+    Inside with block, the line below didn't compile.
+    @value.stripTrailingZeros()
+  }
+  Outside with block is fine: @value.stripTrailingZeros()
+}
+
+@*
+ * Enhanced map loop (test on iterator).
+ *@
+@for ((ForIterator itr, String key, BigDecimal value) : map) {
+  @with (Integer index = itr.index()) {
+    Inside with block, the lines below didn't compile.
+    @itr.index()
+    @itr.first()
+    @itr.last()
+  }
+  Outside with block is fine:
+  @itr.index()
+  @itr.first()
+  @itr.last()
+}

--- a/rocker-test-java8/src/test/java/rocker/ForBlockWithWithBlock.rocker.html
+++ b/rocker-test-java8/src/test/java/rocker/ForBlockWithWithBlock.rocker.html
@@ -1,0 +1,82 @@
+@import java.math.BigDecimal
+@import java.util.List
+@import java.util.Map
+
+@args(List<BigDecimal> list, Map<String,BigDecimal> map)
+
+@*
+ * Collection loop.
+ *@
+@for (value : list) {
+  @with (BigDecimal newObject =	value.stripTrailingZeros()) {
+    Inside with block, the line below didn't compile.
+    @value.toString()
+  }
+  Outside with block is fine: @value.toString()
+}
+
+@*
+ * Collection loop with iterator.
+ *@
+@for ((itr, value) : list) {
+  @with (Integer index = itr.index()) {
+    Inside with block, the lines below didn't compile.
+    @itr.index()
+    @itr.first()
+    @itr.last()
+  }
+  Outside with block is fine:
+  @itr.index()
+  @itr.first()
+  @itr.last()
+}
+
+@*
+ * Indexed loop. Disabled for now, since that requires more changes to the generation.
+ * Currently fails.
+@for (int i = 0; i < list.size(); i++) {
+  @with (BigDecimal newObject =	list.get(i)) {
+    Inside with block, the line below didn't compile.
+    @list.get(i)
+  }
+  Outside with block is fine: @list.get(i)
+}
+*@
+
+@*
+ * Enhanced map loop (test on key).
+ *@
+@for ((key, value) : map) {
+  @with (String newObject =	key.toLowerCase()) {
+    Inside with block, the line below didn't compile.
+    @key.toLowerCase()
+  }
+  Outside with block is fine: @key.toLowerCase()
+}
+
+@*
+ * Enhanced map loop (test on value).
+ *@
+@for ((key, value) : map) {
+  @with (BigDecimal newObject =	value.stripTrailingZeros()) {
+    Inside with block, the line below didn't compile.
+    @value.stripTrailingZeros()
+  }
+  Outside with block is fine: @value.stripTrailingZeros()
+}
+
+@*
+ * Enhanced map loop (test on iterator).
+ *@
+@for ((itr, String key, BigDecimal value) : map) {
+  @with (Integer index = itr.index()) {
+    Inside with block, the lines below didn't compile.
+    @itr.index()
+    @itr.first()
+    @itr.last()
+  }
+  Outside with block is fine:
+  @itr.index()
+  @itr.first()
+  @itr.last()
+}


### PR DESCRIPTION
Pull request as promised. Seems Intellij changed some imports by itself when saving the file, hope you don't mind. I only noticed it now. ;)

"mvn clean install" succeeds for me.

Loop failed to compile. This happened with nested @with blocks that used
the variables in the text block. Fixed by making respective variables final where needed.

One test is currently disabled, the normal for loop as that requires more work to fix.

E.g. sample below @value.toString() below would not compile:

```
@for (BigDecimal value : list) {
  @with (BigDecimal newObject =	value.stripTrailingZeros()) {
    Inside with block, the line below didn't compile.
    @value.toString()
  }
}
```