### PR TITLE
@with block support for multiple arguments

### DIFF
--- a/docs/SYNTAX.md
+++ b/docs/SYNTAX.md
@@ -177,10 +177,10 @@ Note that Rocker has intelligence to skip template content that includes ```{```
 and ```}``` characters such as JavaScript or CSS.  You will not need to escape
 these characters as long as you have matching left and right curly brackets.
 
-### With blocks (set a variable) (@with)
+### With blocks (set one or more variables) (@with)
 
 As of v0.12.0 a `@with` block sets a variable to a value within a scoped block. Once the block
-exits the variable is no longer available.  Variable names cannot conflict with
+exits the variable is no longer available. Variable names cannot conflict with
 other variable names (e.g. arguments) and they will be checked by the Java compiler.
 
 For Java 8 (note this is statically typed and checked at compile time)
@@ -193,6 +193,24 @@ For Java 6/7
 
     @with (String s = list.get(0)) {
         @s
+    }
+    
+As of v0.15.0 a @with block can set more than one variable within the scoped block. Once the block
+exits the variables are no longer available. Variable names cannot conflict with
+other variable names (e.g. arguments) and they will be checked by the Java compiler.
+
+For Java 8 (note this is statically typed and checked at compile time)
+
+    @with (s1 = list.get(0), s2=map.get("key").subList(0,3)) {
+        @s1
+        @s2.get(0)
+    }
+
+For Java 6/7
+
+    @with (String s1 = list.get(0), List<String> s2=map.get("key").subList(0,3)) {
+        @s1
+        @s2.get(0)
     }
 
 ### Null-safe with blocks (@with?)
@@ -213,6 +231,9 @@ Since `list.get(0)` returns null and the `?` presence operator was added to
 `@with` then Rocker would end up rendering `None!`.  Null-safe with blocks are
 incredibly powerful to add prefixes and postfixes to data that may or may not
 exist.
+
+Note: Nullsafe with blocks are not allowed if the with block has multiple arguments.
+      Doing so will result in a compile error.
 
 ### Eval expression (@())
 

--- a/rocker-compiler/src/main/antlr4/com/fizzed/rocker/antlr4/WithBlockLexer.g4
+++ b/rocker-compiler/src/main/antlr4/com/fizzed/rocker/antlr4/WithBlockLexer.g4
@@ -1,0 +1,25 @@
+lexer grammar WithBlockLexer;
+
+ARGUMENT_COMMA
+  :  ARGUMENT ','
+  ;
+
+ARGUMENT
+  :  ( ~( ',' | '(' | '"' | '[' | '<') | JavaString | Parentheses | Array | Generic)+
+  ;
+
+fragment Parentheses
+  :  '(' (Parentheses | ~(')'))* ')'
+  ;
+
+fragment JavaString
+  :  '"' ('\\"' | ~('"'))* '"'
+  ;
+
+fragment Array
+  : '[' (Array | ~(']'))* ']'
+  ;
+
+fragment Generic
+  : '<' (Generic | ~('>'))* '>'
+  ;

--- a/rocker-compiler/src/main/antlr4/com/fizzed/rocker/antlr4/WithBlockParser.g4
+++ b/rocker-compiler/src/main/antlr4/com/fizzed/rocker/antlr4/WithBlockParser.g4
@@ -1,0 +1,13 @@
+parser grammar WithBlockParser;
+
+options {
+    tokenVocab=WithBlockLexer;
+}
+
+start
+  : withArguments EOF
+  ;
+
+withArguments
+  : ARGUMENT_COMMA* ARGUMENT
+  ;

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
@@ -43,7 +43,7 @@ public class JavaGenerator {
     private final RockerConfiguration configuration;
     //private File outputDirectory;
     private PlainTextStrategy plainTextStrategy;
-    
+
     public JavaGenerator(RockerConfiguration configuration) {
         this.configuration = configuration;
         //this.outputDirectory = RockerConfiguration.getInstance().getOutputDirectory();
@@ -156,7 +156,10 @@ public class JavaGenerator {
                 throw new GeneratorException("Error during post-processing of model.", ppe);
             }
         }
-        
+
+        // Used to register any withstatements we encounter, so we can generate all dynamic consumers at the end.
+        final WithStatementConsumerGenerator withStatementConsumerGenerator = new WithStatementConsumerGenerator();
+
         // simple increment to help create unique var names
         int varCounter = -1;
         
@@ -639,30 +642,66 @@ public class JavaGenerator {
             else if (unit instanceof WithBlockBegin) {
                 WithBlockBegin block = (WithBlockBegin)unit;
                 WithStatement stmt = block.getStatement();
-                
+
+                String statementConsumerName = withStatementConsumerGenerator.register(stmt);
+
                 if (isJava8Plus(model)) {
-                
+
+                    // TODO: MRE needs multi vars still
                     tab(w, depth+indent)
                         .append(qualifiedClassName(WithBlock.class))
-                        .append(".with(").append(stmt.getValueExpression())
+                        .append(".with(").append(stmt.getVariables().get(0).getValueExpression())
                         .append(", ").append(stmt.isNullSafe()+"")
-                        .append(", (").append(stmt.getVariable().toString()).append(") -> {").append(CRLF);
-                
-                    depth++;
-                
-                    blockEnd.push("});");
-                
-                } else {
-                    
-                    tab(w, depth+indent)
-                        .append(qualifiedClassName(WithBlock.class))
-                        .append(".with(").append(stmt.getValueExpression())
-                        .append(", ").append(stmt.isNullSafe()+"")
-                        .append(", (new ").append(qualifiedClassName(WithBlock.Consumer1.class)).append("<").append(stmt.getVariable().getType()).append(">() { ")
-                        .append("@Override public void accept(final ").append(stmt.getVariable().toString()).append(") throws IOException {").append(CRLF);
+                        .append(", (").append(stmt.getVariables().get(0).getVariable().getName()).append(") -> {").append(CRLF);
 
                     depth++;
-                
+
+                    blockEnd.push("});");
+
+                }
+                else {
+
+                    final List<WithStatement.VariableWithExpression> variables = stmt.getVariables();
+
+                    tab(w, depth+indent)
+                        // Note for standard 1 variable with block we use the predefined consumers.
+                        // Otherwise we fallback to the generated ones.
+                        .append(variables.size() == 1 ? qualifiedClassName(WithBlock.class) : WithStatementConsumerGenerator.WITH_BLOCKS_GENERATED_CLASS_NAME)
+                        .append(".with(");
+
+                    // All expressions
+                    for(int i = 0; i < variables.size(); i++) {
+                        final WithStatement.VariableWithExpression var = variables.get(i);
+                        if(i > 0) {
+                            w.append(", ");
+                        }
+                        w.append(var.getValueExpression());
+                    }
+                    w.append(", ").append(stmt.isNullSafe()+"")
+                        .append(", (new ").append(statementConsumerName).append('<');
+
+                    // Types for the .with(..)
+                    for(int i = 0; i < variables.size(); i++) {
+                        final JavaVariable variable = variables.get(i).getVariable();
+                        if(i > 0) {
+                            w.append(", ");
+                        }
+                        w.append(variable.getType());
+                    }
+                    w.append(">() {").append(CRLF);
+                    tab(w, depth+indent+1)
+                        .append("@Override public void accept(");
+                    for(int i = 0; i < variables.size(); i++) {
+                        final JavaVariable variable = variables.get(i).getVariable();
+                        if(i > 0) {
+                            w.append(", ");
+                        }
+                        w.append("final ").append(variable.toString());
+                    }
+                    w.append(") throws IOException {").append(CRLF);
+
+                    depth++;
+
                     blockEnd.push("}}));");
                 }
             }
@@ -896,8 +935,10 @@ public class JavaGenerator {
         
         // end of template class
         tab(w, indent).append("}").append(CRLF);
-        
-        
+
+        // Generate class with all gathered consumer interfaces for all withblocks
+        withStatementConsumerGenerator.generate(this, w);
+
         if (this.plainTextStrategy == PlainTextStrategy.STATIC_BYTE_ARRAYS_VIA_UNLOADED_CLASS &&
                 !plainTextMap.isEmpty()) {
             

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/WithBlockParserListener.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/WithBlockParserListener.java
@@ -1,0 +1,33 @@
+package com.fizzed.rocker.compiler;
+
+import com.fizzed.rocker.antlr4.WithBlockParser;
+import com.fizzed.rocker.antlr4.WithBlockParserBaseListener;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * WithBlock listener, gathers the arguments in a list.
+ */
+public class WithBlockParserListener extends WithBlockParserBaseListener {
+
+    private final List<String> arguments = new ArrayList<>();
+
+    @Override
+    public void enterWithArguments(WithBlockParser.WithArgumentsContext ctx) {
+         for(final TerminalNode node : ctx.ARGUMENT_COMMA()) {
+             final String text = node.getText();
+             arguments.add(text.substring(0, text.length()-1)); // Chop off the , at the end.
+         }
+         arguments.add(ctx.ARGUMENT().getText());
+    }
+
+    public List<String> getArguments() {
+        return arguments;
+    }
+
+    public void clear() {
+        arguments.clear();
+    }
+}

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/WithStatementConsumerGenerator.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/WithStatementConsumerGenerator.java
@@ -54,7 +54,7 @@ public class WithStatementConsumerGenerator {
                 if (i > 0) {
                     w.append(", ");
                 }
-                w.append("V" + i);
+                w.append("V").append(String.valueOf(i));
             }
             w.append('>').append(" { ").append(CRLF).append(CRLF);
             generator.tab(w, 3)
@@ -64,7 +64,7 @@ public class WithStatementConsumerGenerator {
                 if (i > 0) {
                     w.append(", ");
                 }
-                w.append("V" + i).append(" v" + i);
+                w.append("V").append(String.valueOf(i)).append(" v").append(String.valueOf(i));
             }
             w.append(") throws IOException;").append(CRLF).append(CRLF);
             generator.tab(w, 2)
@@ -81,23 +81,31 @@ public class WithStatementConsumerGenerator {
                 if (i > 0) {
                     w.append(", ");
                 }
-                w.append("V" + i);
+                w.append("V").append(String.valueOf(i));
             }
             w.append("> void with (");
             for (int i = 0; i < typeCount; i++) {
                 if (i > 0) {
                     w.append(", ");
                 }
-                w.append("V" + i).append(" v" + i);
+                w.append("V").append(String.valueOf(i)).append(" v").append(String.valueOf(i));
             }
-            w.append(", boolean nullSafe, ").append(className).append(" consumer) throws IOException {").append(CRLF);
+            w.append(", boolean nullSafe, ");
+            w.append(className).append('<');
+            for (int i = 0; i < typeCount; i++) {
+                if (i > 0) {
+                    w.append(", ");
+                }
+                w.append("V").append(String.valueOf(i));
+            }
+            w.append("> consumer) throws IOException {").append(CRLF);
             generator.tab(w, 3)
                 .append("consumer.accept(");
                 for (int i = 0; i < typeCount; i++) {
                     if (i > 0) {
                         w.append(", ");
                     }
-                    w.append("v" + i);
+                    w.append("v").append(String.valueOf(i));
                 }
                 w.append(");").append(CRLF);
             generator.tab(w, 2)
@@ -107,27 +115,3 @@ public class WithStatementConsumerGenerator {
         generator.tab(w, 1).append("}").append(CRLF);
     }
 }
-
-/*
-    public interface Consumer0 {
-        void accept() throws IOException;
-    }
-
-    public interface Consumer1<V> {
-        void accept(V v) throws IOException;
-    }
-
-    static public <V> void with(V v, boolean nullSafe, Consumer1<V> consumer) throws IOException {
-        if (!nullSafe || v != null) {
-            consumer.accept(v);
-        }
-    }
-
-    static public <V> void with(V v, boolean nullSafe, Consumer1<V> consumer, Consumer0 elseConsumer) throws IOException {
-        if (!nullSafe || v != null) {
-            consumer.accept(v);
-        } else {
-            elseConsumer.accept();
-        }
-    }
- */

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/WithStatementConsumerGenerator.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/WithStatementConsumerGenerator.java
@@ -1,0 +1,133 @@
+package com.fizzed.rocker.compiler;
+
+import com.fizzed.rocker.model.WithStatement;
+import com.fizzed.rocker.runtime.WithBlock;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static com.fizzed.rocker.compiler.JavaGenerator.CRLF;
+
+/**
+ * We use this class to generate a withblock consumer while generating the template.
+ * Since we allow 1 or more with assignments, we cannot rely on a static consumer anymore.
+ * The JavaParser gathers the relevant WithBlocks it comes across, and at the end of the
+ * template we generate the relevant consumers using this helper class.
+ *
+ * @author mreuvers
+ */
+public class WithStatementConsumerGenerator {
+
+    protected static final String WITH_BLOCKS_GENERATED_CLASS_NAME = "WithBlocksGenerated0";
+
+    // Each number registered represents the consumer we must generate, where
+    // the number represents the number of types.
+    private final Set<Integer> withStatementsTypeCounts = new TreeSet<>();
+
+    public String register(final WithStatement statement) {
+        final int typeCount = statement.getVariables().size();
+        if(typeCount > 1) {
+            final String className = "WithStatementConsumer" + typeCount;
+
+            withStatementsTypeCounts.add(typeCount);
+            return WITH_BLOCKS_GENERATED_CLASS_NAME + "." + className;
+        }
+        return RockerUtil.qualifiedClassName(WithBlock.Consumer1.class);
+    }
+
+    public void generate(final JavaGenerator generator, final Writer w) throws IOException {
+        if (withStatementsTypeCounts.isEmpty()) {
+            return;
+        }
+
+        generator.tab(w, 1).append("private static class ").append(WITH_BLOCKS_GENERATED_CLASS_NAME).append(" { ").append(CRLF);
+
+        for (final Integer typeCount : withStatementsTypeCounts) {
+            final String className = "WithStatementConsumer" + typeCount;
+
+            // Types it accepts.
+            generator.tab(w, 2)
+                .append("interface ").append(className).append('<');
+            for (int i = 0; i < typeCount; i++) {
+                if (i > 0) {
+                    w.append(", ");
+                }
+                w.append("V" + i);
+            }
+            w.append('>').append(" { ").append(CRLF).append(CRLF);
+            generator.tab(w, 3)
+                .append("void accept(");
+            // Variables for the accept
+            for (int i = 0; i < typeCount; i++) {
+                if (i > 0) {
+                    w.append(", ");
+                }
+                w.append("V" + i).append(" v" + i);
+            }
+            w.append(") throws IOException;").append(CRLF).append(CRLF);
+            generator.tab(w, 2)
+                .append('}').append(CRLF);
+        }
+
+        // Generate the static with(..) methods
+        for (final Integer typeCount : withStatementsTypeCounts) {
+            final String className = "WithStatementConsumer" + typeCount;
+
+            generator.tab(w, 2)
+                .append("static public <");
+            for (int i = 0; i < typeCount; i++) {
+                if (i > 0) {
+                    w.append(", ");
+                }
+                w.append("V" + i);
+            }
+            w.append("> void with (");
+            for (int i = 0; i < typeCount; i++) {
+                if (i > 0) {
+                    w.append(", ");
+                }
+                w.append("V" + i).append(" v" + i);
+            }
+            w.append(", boolean nullSafe, ").append(className).append(" consumer) throws IOException {").append(CRLF);
+            generator.tab(w, 3)
+                .append("consumer.accept(");
+                for (int i = 0; i < typeCount; i++) {
+                    if (i > 0) {
+                        w.append(", ");
+                    }
+                    w.append("v" + i);
+                }
+                w.append(");").append(CRLF);
+            generator.tab(w, 2)
+                .append("}").append(CRLF);
+        }
+
+        generator.tab(w, 1).append("}").append(CRLF);
+    }
+}
+
+/*
+    public interface Consumer0 {
+        void accept() throws IOException;
+    }
+
+    public interface Consumer1<V> {
+        void accept(V v) throws IOException;
+    }
+
+    static public <V> void with(V v, boolean nullSafe, Consumer1<V> consumer) throws IOException {
+        if (!nullSafe || v != null) {
+            consumer.accept(v);
+        }
+    }
+
+    static public <V> void with(V v, boolean nullSafe, Consumer1<V> consumer, Consumer0 elseConsumer) throws IOException {
+        if (!nullSafe || v != null) {
+            consumer.accept(v);
+        } else {
+            elseConsumer.accept();
+        }
+    }
+ */

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/model/WithStatement.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/model/WithStatement.java
@@ -15,30 +15,44 @@
  */
 package com.fizzed.rocker.model;
 
-import com.fizzed.rocker.compiler.TokenException;
+import com.fizzed.rocker.antlr4.WithBlockLexer;
+import com.fizzed.rocker.antlr4.WithBlockParser;
+import com.fizzed.rocker.compiler.*;
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class WithStatement implements NullSafety {
-    
-    private final JavaVariable variable;
-    private final String valueExpression;
+
+    private static final WithBlockParserListener WITH_BLOCK_PARSER_LISTENER = new WithBlockParserListener();
+
+    private final List<VariableWithExpression> variables;
     private final boolean nullSafe;
     
-    public WithStatement(JavaVariable variable, String valueExpression) {
-        this(variable, valueExpression, false);
+    public WithStatement(List<VariableWithExpression> variables) {
+        this(variables, false);
     }
     
-    public WithStatement(JavaVariable variable, String valueExpression, boolean nullSafe) {
-        this.variable = variable;
-        this.valueExpression = valueExpression;
+    public WithStatement(List<VariableWithExpression> variables, boolean nullSafe) {
+        this.variables = variables;
         this.nullSafe = nullSafe;
     }
 
-    public JavaVariable getVariable() {
-        return variable;
+    public List<VariableWithExpression> getVariables() {
+        return variables;
     }
 
-    public String getValueExpression() {
-        return valueExpression;
+    public boolean hasAnyVariableNullType() {
+        for(VariableWithExpression v : variables) {
+            if(v.getVariable().getType() == null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -46,7 +60,7 @@ public class WithStatement implements NullSafety {
         return nullSafe;
     }
     
-    static public WithStatement parse(String statement) throws TokenException
+    static public WithStatement parse(String statement, String templatePath) throws TokenException
     {
         // possible its starts with a '?' mark
         boolean nullSafe = false;
@@ -67,29 +81,99 @@ public class WithStatement implements NullSafety {
         
         // chomp parentheses
         statement = statement.substring(1, statement.length() - 1);
-        
-        int equalsPos = statement.indexOf('=');
-        if (equalsPos < 0) {
-            throw new TokenException("With block invalid: no equals symbol found");
+
+        // We now support multiple with statements, break them apart based on the comma.
+        final List<VariableWithExpression> variables = new ArrayList<>();
+
+        final List<String> withStatements = parseWithStatement(statement, templatePath);
+        for(int i = 0; i < withStatements.size(); i++) {
+            final String withStatement = withStatements.get(i);
+
+            // The normal logic what a with variable assignment must look like applies for each separate assignment
+            final int equalsPos = withStatement.indexOf('=');
+            if (equalsPos < 0) {
+                throw new TokenException("With block invalid: no equals symbol found for assignment: " + withStatement);
+            }
+            // multiple equals chars?
+            if (withStatement.indexOf('=', equalsPos+1) > 0) {
+                throw new TokenException("With block invalid: multiple equals symbols found for assignment " + withStatement);
+            }
+
+            final String varPart = withStatement.substring(0, equalsPos);
+
+            // parse variable
+            final JavaVariable variable = JavaVariable.parse(varPart);
+            final String valueExpression = withStatement.substring(equalsPos+1).trim();
+
+            // verify its not an empty string
+            if (valueExpression.equals("")) {
+                throw new TokenException("With block contains an empty string for value part (e.g. var = value)");
+            }
+
+            //if()
+
+            variables.add(new VariableWithExpression(variable, valueExpression));
         }
-        
-        // multiple equals chars?
-        if (statement.indexOf('=', equalsPos+1) > 0) {
-            throw new TokenException("With block invalid: multiple equals symbols found");
-        }
-        
-        String varPart = statement.substring(0, equalsPos);
 
-        // parse variable
-        JavaVariable variable = JavaVariable.parse(varPart);
-
-        String valueExpression = statement.substring(equalsPos+1).trim();
-
-        // verify its not an empty string
-        if (valueExpression.equals("")) {
-            throw new TokenException("With block contains an empty string for value part (e.g. var = value)");
+        // We do not allow nullSafe with more than one argument
+        if(nullSafe && variables.size() > 1) {
+            throw new TokenException("Nullsafe option not allowed for with block with multiple arguments");
         }
 
-        return new WithStatement(variable, valueExpression, nullSafe);
+        return new WithStatement(variables, nullSafe);
+    }
+
+    private static List<String> parseWithStatement(final String value, final String templatePath) {
+        final Lexer lexer = new WithBlockLexer(new ANTLRInputStream(value));
+        lexer.removeErrorListeners();
+        lexer.addErrorListener(new DescriptiveErrorListener());
+
+        final CommonTokenStream in;
+
+        try {
+            in = new CommonTokenStream(lexer);
+
+            final WithBlockParser parser = new WithBlockParser(in);
+            parser.removeErrorListeners();
+            parser.addErrorListener(new DescriptiveErrorListener());
+            final WithBlockParser.StartContext start = parser.start();
+
+            WITH_BLOCK_PARSER_LISTENER.clear();
+            ParseTreeWalker.DEFAULT.walk(WITH_BLOCK_PARSER_LISTENER, start);
+            return WITH_BLOCK_PARSER_LISTENER.getArguments();
+        }
+        catch (ParserRuntimeException e) {
+            throw TemplateParser.unwrapParserRuntimeException(templatePath, e);
+        }
+    }
+
+    /**
+     * Wrapper around one variable and its expression
+     */
+    public static class VariableWithExpression {
+
+        private final JavaVariable variable;
+        private final String valueExpression;
+
+        private VariableWithExpression(JavaVariable variable, String valueExpression) {
+            this.variable = variable;
+            this.valueExpression = valueExpression;
+        }
+
+        public JavaVariable getVariable() {
+            return variable;
+        }
+
+        public String getValueExpression() {
+            return valueExpression;
+        }
+
+        @Override
+        public String toString() {
+            return "VariableWithExpression{" +
+              "variable=" + variable +
+              ", valueExpression='" + valueExpression + '\'' +
+              '}';
+        }
     }
 }

--- a/rocker-compiler/src/test/java/com/fizzed/rocker/bin/ParserMain.java
+++ b/rocker-compiler/src/test/java/com/fizzed/rocker/bin/ParserMain.java
@@ -15,32 +15,17 @@
  */
 package com.fizzed.rocker.bin;
 
-import com.fizzed.rocker.runtime.ParserException;
-import com.fizzed.rocker.model.Argument;
-import com.fizzed.rocker.model.Comment;
-import com.fizzed.rocker.model.IfBlockElse;
-import com.fizzed.rocker.model.ForBlockBegin;
-import com.fizzed.rocker.model.ForBlockEnd;
-import com.fizzed.rocker.model.WithBlockBegin;
-import com.fizzed.rocker.model.WithBlockEnd;
-import com.fizzed.rocker.model.IfBlockBegin;
-import com.fizzed.rocker.model.IfBlockEnd;
-import com.fizzed.rocker.model.JavaImport;
-import com.fizzed.rocker.model.PlainText;
-import com.fizzed.rocker.model.TemplateModel;
-import com.fizzed.rocker.model.TemplateUnit;
-import com.fizzed.rocker.model.ValueExpression;
-import java.io.File;
-import java.io.IOException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ch.qos.logback.classic.Level;
 import com.fizzed.rocker.compiler.RockerConfiguration;
 import com.fizzed.rocker.compiler.RockerUtil;
 import com.fizzed.rocker.compiler.TemplateParser;
-import com.fizzed.rocker.model.BreakStatement;
-import com.fizzed.rocker.model.ContinueStatement;
-import com.fizzed.rocker.model.NullTernaryExpression;
+import com.fizzed.rocker.model.*;
+import com.fizzed.rocker.runtime.ParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
 
 public class ParserMain {
     static private final Logger log = LoggerFactory.getLogger(ParserMain.class);
@@ -127,7 +112,7 @@ public class ParserMain {
                 log.info("for end:");
             } else if (unit instanceof WithBlockBegin) {
                 WithBlockBegin block = (WithBlockBegin)unit;
-                log.info("with begin: isNullSafe={} ({} = {})", block.getStatement().isNullSafe(), block.getStatement().getVariable(), block.getStatement().getValueExpression());
+                log.info("with begin: isNullSafe={} ({} = {})", block.getStatement().isNullSafe(), block.getStatement().getVariables());
             } else if (unit instanceof WithBlockEnd) {
                 log.info("with end:");
             } else if (unit instanceof IfBlockBegin) {

--- a/rocker-compiler/src/test/java/com/fizzed/rocker/model/WithStatementTest.java
+++ b/rocker-compiler/src/test/java/com/fizzed/rocker/model/WithStatementTest.java
@@ -16,11 +16,15 @@
 package com.fizzed.rocker.model;
 
 import com.fizzed.rocker.compiler.TokenException;
+import com.fizzed.rocker.runtime.ParserException;
+import org.junit.Test;
+
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import org.junit.Test;
 
 public class WithStatementTest {
     
@@ -28,7 +32,7 @@ public class WithStatementTest {
     public void notStartOrEndWithParenthese() throws Exception {
         try {
             // missing starting parenthese
-            WithStatement.parse("String s = \"test\"");
+            WithStatement.parse("String s = \"test\"", "template-path");
             fail("Expected exception");
         } catch (TokenException e) {
             assertThat(e.getMessage(), containsString("start with parenthese"));
@@ -36,7 +40,7 @@ public class WithStatementTest {
         
         try {
             // missing ending parenthese
-            WithStatement.parse("(String s = \"test\"");
+            WithStatement.parse("(String s = \"test\"", "template-path");
             fail("Expected exception");
         } catch (TokenException e) {
             assertThat(e.getMessage(), containsString("end with parenthese"));
@@ -47,7 +51,7 @@ public class WithStatementTest {
     public void noEqualsChar() throws Exception {
         try {
             // missing starting parenthese
-            WithStatement.parse("(String s -> \"test\")");
+            WithStatement.parse("(String s -> \"test\")", "template-path");
             fail("Expected exception");
         } catch (TokenException e) {
             assertThat(e.getMessage(), containsString("no equals symbol"));
@@ -58,20 +62,34 @@ public class WithStatementTest {
     public void multipleEqualsChar() throws Exception {
         try {
             // missing starting parenthese
-            WithStatement.parse("(String s = \"test\"; String t = \"test\")");
+            WithStatement.parse("(String s = \"test\"; String t = \"test\")", "template-path");
             fail("Expected exception");
         } catch (TokenException e) {
             assertThat(e.getMessage(), containsString("multiple equals symbol"));
         }
     }
-    
+
+    @Test
+    public void endsWithComma() throws Exception {
+        try {
+            WithStatement.parse(("(String s = \"test\",)"), "template-path");
+            fail("Expected exception");
+        }
+        catch(ParserException e) {
+            assertThat(e.getMessage(), containsString("template-path:[1,18] missing ARGUMENT at '<EOF>'"));
+        }
+    }
+
     @Test
     public void works() throws Exception {
-        WithStatement with = WithStatement.parse("(String s = \"test\")");
-        
-        assertThat(with.getVariable().getName(), is("s"));
-        assertThat(with.getVariable().getType(), is("String"));
-        assertThat(with.getValueExpression(), is("\"test\""));
+        WithStatement with = WithStatement.parse("(String s = \"test\")", "template-path");
+
+        final List<WithStatement.VariableWithExpression> variablesWithExpressions = with.getVariables();
+        final WithStatement.VariableWithExpression variableWithExpression = variablesWithExpressions.get(0);
+
+        assertThat(variableWithExpression.getVariable().getName(), is("s"));
+        assertThat(variableWithExpression.getVariable().getType(), is("String"));
+        assertThat(variableWithExpression.getValueExpression(), is("\"test\""));
     }
     
 }

--- a/rocker-compiler/src/test/resources/rocker/parser/WithBlockMultipleArguments.rocker.html
+++ b/rocker-compiler/src/test/resources/rocker/parser/WithBlockMultipleArguments.rocker.html
@@ -1,0 +1,8 @@
+@import java.util.List
+@import java.util.Map
+@args (List<String> a, Map<String, List<String>> map)
+@with (String b = a.get(0), List<String> list = map.get("abc"), Long value = Long.valueOf(a.get(0))) {
+  @b
+  @list.get(0)
+  @value.toString()
+}

--- a/rocker-compiler/src/test/resources/rocker/parser/WithBlockMultipleArgumentsNullSafeFails.rocker.html
+++ b/rocker-compiler/src/test/resources/rocker/parser/WithBlockMultipleArgumentsNullSafeFails.rocker.html
@@ -1,0 +1,7 @@
+@import java.util.List
+@import java.util.Map
+@args (List<String> a, Map<String, List<String>> map)
+@with? (String b = a.get(0), List<String> list = map.get("abc")) {
+  @b
+  @list.get(0)
+}

--- a/rocker-runtime/src/main/java/com/fizzed/rocker/runtime/WithBlock.java
+++ b/rocker-runtime/src/main/java/com/fizzed/rocker/runtime/WithBlock.java
@@ -18,12 +18,12 @@ package com.fizzed.rocker.runtime;
 import java.io.IOException;
 
 public class WithBlock {
-    
-    static public interface Consumer0 {
+
+    public interface Consumer0 {
         void accept() throws IOException;
     }
     
-    static public interface Consumer1<V> {
+    public interface Consumer1<V> {
         void accept(V v) throws IOException;
     }
     

--- a/rocker-test-java6/src/test/java/rocker/WithBlockWithMultipleArguments.rocker.html
+++ b/rocker-test-java6/src/test/java/rocker/WithBlockWithMultipleArguments.rocker.html
@@ -1,6 +1,7 @@
 @import java.util.ArrayList
 @import java.util.List
 @import java.util.Map
+@import java.util.HashMap
 
 @args(List<String> strings)
 
@@ -51,6 +52,6 @@ else {
 }
 
 
-@with (String s=strings.get(0), Map<String,List<Map<String,Long>>> value = null, List<String[]> list = new ArrayList<String[]>(5)) {
+@with (String s=strings.get(0), Map<String,List<Map<String,Long>>> value = new HashMap<String,List<Map<String,Long>>>(), List<String[]> list = new ArrayList<String[]>(5)) {
   @s @value
 }

--- a/rocker-test-java6/src/test/java/rocker/WithBlockWithMultipleArguments.rocker.html
+++ b/rocker-test-java6/src/test/java/rocker/WithBlockWithMultipleArguments.rocker.html
@@ -1,0 +1,56 @@
+@import java.util.ArrayList
+@import java.util.List
+@import java.util.Map
+
+@args(List<String> strings)
+
+@with (String s = strings.get(0), String s2=strings.get(1), String lower=strings.get(2).toLowerCase()) {
+  @s
+  @s2
+  @lower
+}
+
+@with (String s = strings.get(0), Long value=new Long(100)) {
+  @s
+  @value
+  multiple
+}
+
+@with (String s = strings.get(0), Long value=new Long(100)) {
+  @s
+  @value
+  @with (String v = s.toLowerCase(),
+         List<String> subs = strings.subList(1,2),
+         List<String> anotherSubs=strings.subList(0,1).subList(0,1),
+         String t = "hello, world",
+         Boolean region="".regionMatches(true, 0, ",e,,\n,",5,3),
+         String escapeSelf=",,,") {
+    // Nested
+    @v
+    @subs.toString()
+    @anotherSubs
+    @t
+    @region
+    @escapeSelf
+    @s
+    @value
+  }
+}
+
+
+@with (String s=strings.get(0)) {
+  @s
+}
+
+
+@with? (String s=strings.get(0)) {
+  @s
+}
+else {
+  else is allowed with nullsafe.
+}
+
+
+@with (String s=strings.get(0), Map<String,List<Map<String,Long>>> value = null, List<String[]> list = new ArrayList<String[]>(5)) {
+  @s @value
+}

--- a/rocker-test-java8/src/test/java/rocker/WithBlockWithMultipleArgumentsJava8.rocker.html
+++ b/rocker-test-java8/src/test/java/rocker/WithBlockWithMultipleArgumentsJava8.rocker.html
@@ -1,0 +1,57 @@
+@import java.util.ArrayList
+@import java.util.List
+@import java.util.Map
+@import java.util.HashMap
+
+@args(List<String> strings)
+
+@with (s = strings.get(0), s2=strings.get(1), lower=strings.get(2).toLowerCase()) {
+  @s
+  @s2
+  @lower
+}
+
+@with (s = strings.get(0), value=new Long(100)) {
+  @s
+  @value
+  multiple
+}
+
+@with (s = strings.get(0), value=new Long(100)) {
+  @s
+  @value
+  @with (v = s.toLowerCase(),
+         subs = strings.subList(1,2),
+         anotherSubs=strings.subList(0,1).subList(0,1),
+         t = "hello, world",
+         region="".regionMatches(true, 0, ",e,,\n,",5,3),
+         escapeSelf=",,,") {
+    // Nested
+    @v
+    @subs.toString()
+    @anotherSubs
+    @t
+    @region
+    @escapeSelf
+    @s
+    @value
+  }
+}
+
+
+@with (s=strings.get(0)) {
+  @s
+}
+
+
+@with? (s=strings.get(0)) {
+  @s
+}
+else {
+  else is allowed with nullsafe.
+}
+
+
+@with (s=strings.get(0), value = new HashMap<String,List<Map<String,Long>>>(), list = new ArrayList<String[]>(5)) {
+  @s @value
+}


### PR DESCRIPTION
Hey @jjlauer,

This is the pull request to make the with block support multiple arguments. It supports a single argument still of course, and multiple arguments now  as well (separated by a comma). By using a separate antlr parser to split the arguments correctly (you may be able to reuse that in the future, to parse other multi argument strings). So no escaping is necessary.

In addition the else is not allowed anymore for with? blocks with multiple arguments.

I've added tests for both java6 and java8. All new and existing tests (still) pass.

I also updated the syntax.md file  (I put a since version 0.15 for this, assuming you would bump the release to that version later, if not you need to change that). 

Could you merge this in and create a release later on?

Thanks!
Martijn

