### PR TITLE
Pull request to address issue #55

### DIFF
--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
@@ -217,7 +217,12 @@ public class JavaGenerator {
         tab(w, indent).append("static public final String TEMPLATE_NAME = \"").append(model.getTemplateName()).append("\";").append(CRLF);
         tab(w, indent).append("static public final String TEMPLATE_PACKAGE_NAME = \"").append(model.getPackageName()).append("\";").append(CRLF);
         tab(w, indent).append("static public final String HEADER_HASH = \"").append(model.createHeaderHash()+"").append("\";").append(CRLF);
-        tab(w, indent).append("static public final long MODIFIED_AT = ").append(model.getModifiedAt()+"").append("L;").append(CRLF);
+
+        // Don't include MODIFIED_AT header when optimized compiler is used since this implicitly disables hot reloading anyhow
+        if (!model.getOptions().getOptimize()) {
+            tab(w, indent).append("static public final long MODIFIED_AT = ").append(model.getModifiedAt() + "").append("L;").append(CRLF);
+        }
+
         tab(w, indent).append("static public final String[] ARGUMENT_NAMES = {");
         StringBuilder argNameList = new StringBuilder();
         for (Argument arg : model.getArgumentsWithoutRockerBody()) {

--- a/rocker-test-java6/src/test/java/com/fizzed/rocker/compiler/CompiledTemplateTest.java
+++ b/rocker-test-java6/src/test/java/com/fizzed/rocker/compiler/CompiledTemplateTest.java
@@ -18,6 +18,7 @@ package com.fizzed.rocker.compiler;
 import com.fizzed.rocker.RenderingException;
 import com.fizzed.test.User;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,6 +37,7 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import rocker.NoHeader;
 
 public class CompiledTemplateTest {
     static private final Logger log = LoggerFactory.getLogger(CompiledTemplateTest.class);
@@ -903,5 +905,9 @@ public class CompiledTemplateTest {
         
         assertThat(html, is("b"));
     }
-    
+
+    @Test(expected = NoSuchFieldException.class)
+    public void optmizedCompilerOmitsModifedAtHeader() throws Exception {
+        rocker.A.class.getField("MODIFIED_AT");
+    }
 }

--- a/rocker-test-java6/src/test/java/com/fizzed/rocker/compiler/CompiledTemplateTest.java
+++ b/rocker-test-java6/src/test/java/com/fizzed/rocker/compiler/CompiledTemplateTest.java
@@ -18,7 +18,6 @@ package com.fizzed.rocker.compiler;
 import com.fizzed.rocker.RenderingException;
 import com.fizzed.test.User;
 import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -37,7 +36,6 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import rocker.NoHeader;
 
 public class CompiledTemplateTest {
     static private final Logger log = LoggerFactory.getLogger(CompiledTemplateTest.class);


### PR DESCRIPTION
This PR fixes issue #55 by omitting the `MODIFIED_AT` header field when the `optimize` compiler option is used.