### PR TITLE
Fix typo in log message.

### DIFF
--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGeneratorMain.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGeneratorMain.java
@@ -140,7 +140,7 @@ public class JavaGeneratorMain {
             this.configuration.write(configFile);
             log.info("Generated rocker configuration " + configFile);
         } else {
-            log.info("Optimize flag off. Did not generate rocker configuration file");
+            log.info("Optimize flag on. Did not generate rocker configuration file");
         }
     }
     


### PR DESCRIPTION
This PR fixes a typo in the generator logging that states that rocker config file generation was skipped due to optimization being _off_. This is in fact incorrect as this happens when the optimize is _on_. 

This actually sent me off on a 30 minute expedition to figure out what I was doing wrong when passing option flags to the generator :)