### PR TITLE
Extract runner logic from JavaGeneratorMain into Runnable interface

### DIFF
--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGeneratorMain.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGeneratorMain.java
@@ -15,138 +15,20 @@
  */
 package com.fizzed.rocker.compiler;
 
-import com.fizzed.rocker.runtime.ParserException;
-import com.fizzed.rocker.model.TemplateModel;
-import com.fizzed.rocker.runtime.RockerRuntime;
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author joelauer
  */
 public class JavaGeneratorMain {
-    private static final Logger log = LoggerFactory.getLogger(JavaGeneratorMain.class);
-    
-    private final RockerConfiguration configuration;
-    private final TemplateParser parser;
-    private final JavaGenerator generator;
-    private final List<File> templateFiles;
-    private String suffixRegex;
-    private boolean failOnError;
-    
-    public JavaGeneratorMain() {
-        this.configuration = new RockerConfiguration();
-        this.parser = new TemplateParser(this.configuration);
-        this.generator = new JavaGenerator(this.configuration);
-        this.templateFiles = new ArrayList<>();
-        this.suffixRegex = ".*\\.rocker\\.(raw|html)$";
-        this.failOnError = true;
-    }
 
-    public String getSuffixRegex() {
-        return suffixRegex;
-    }
-
-    public void setSuffixRegex(String suffixRegex) {
-        this.suffixRegex = suffixRegex;
-    }
-
-    public boolean isFailOnError() {
-        return failOnError;
-    }
-
-    public void setFailOnError(boolean failOnError) {
-        this.failOnError = failOnError;
-    }
-
-    public TemplateParser getParser() {
-        return parser;
-    }
-
-    public JavaGenerator getGenerator() {
-        return generator;
-    }
-    
-    public void run() throws Exception {
-        if (this.configuration.getTemplateDirectory() == null) {
-            throw new Exception("Template directory was null");
-        }
-        
-        if (!this.configuration.getTemplateDirectory().exists() || !this.configuration.getTemplateDirectory().isDirectory()) {
-            throw new Exception("Template directory does not exist: " + this.configuration.getTemplateDirectory());
-        }
-        
-        // loop thru template directory and match templates
-        Collection<File> allFiles = RockerUtil.listFileTree(this.configuration.getTemplateDirectory());
-        for (File f : allFiles) {
-            if (f.getName().matches(suffixRegex)) {
-                templateFiles.add(f);
-            }
-        }
-        
-        log.info("Parsing " + templateFiles.size() + " rocker template files");
-        
-        int errors = 0;
-        int generated = 0;
-        
-        for (File f : templateFiles) { 
-            TemplateModel model = null;
-        
-            try {
-                // parse model
-                model = parser.parse(f); 
-            } catch (IOException | ParserException e) {
-                if (e instanceof ParserException) {
-                    ParserException pe = (ParserException)e;
-                    log.error("Parsing failed for " + f + ":[" + pe.getLineNumber() + "," + pe.getColumnNumber() + "] " + pe.getMessage());
-                } else {
-                    log.error("Unable to parse template", e);
-                }
-                errors++;
-            }
-            
-            try {
-                File outputFile = generator.generate(model);
-                generated++;
-
-                log.debug("Generated java source: " + outputFile);
-            } catch (GeneratorException | IOException e) {
-                throw new Exception("Generating java source failed for " + f + ": " + e.getMessage(), e);
-            }
-            
-        }
-        
-        log.info("Generated " + generated + " rocker java source files");
-        
-        if (errors > 0 && failOnError) {
-            throw new Exception("Caught " + errors + " errors.");
-        }
-        
-        if (!configuration.getOptions().getOptimize()) {
-            // save configuration
-            this.configuration.getClassDirectory().mkdirs();
-            
-            // use resource name, but strip leading slash
-            // place it into the classes directory (not the compile directory)
-            File configFile = new File(this.configuration.getClassDirectory(), RockerRuntime.CONF_RESOURCE_NAME.substring(1));
-            this.configuration.write(configFile);
-            log.info("Generated rocker configuration " + configFile);
-        } else {
-            log.info("Optimize flag on. Did not generate rocker configuration file");
-        }
-    }
     
     static public void main(String[] a) throws Exception {
 
-        JavaGeneratorMain jgm = new JavaGeneratorMain();
+        JavaGeneratorRunnable jgr = new JavaGeneratorRunnable();
         
         // process command-line arguments
         ArrayDeque<String> args = new ArrayDeque<>(a.length);
@@ -162,14 +44,14 @@ public class JavaGeneratorMain {
             
             switch (n) {
                 case "-t":
-                    jgm.parser.getConfiguration().setTemplateDirectory(new File(v));
+                    jgr.setTemplateDirectory(new File(v));
                     break;
                 case "-o":
-                    jgm.generator.getConfiguration().setOutputDirectory(new File(v));
+                    jgr.setOutputDirectory(new File(v));
                     break;
             }
         }
         
-        jgm.run();
+        jgr.run();
     }
 }

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGeneratorRunnable.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGeneratorRunnable.java
@@ -1,0 +1,138 @@
+package com.fizzed.rocker.compiler;
+
+import com.fizzed.rocker.model.TemplateModel;
+import com.fizzed.rocker.runtime.ParserException;
+import com.fizzed.rocker.runtime.RockerRuntime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class JavaGeneratorRunnable implements Runnable {
+    private static final Logger log = LoggerFactory.getLogger(JavaGeneratorMain.class);
+
+    private final RockerConfiguration configuration;
+    private final TemplateParser parser;
+    private final JavaGenerator generator;
+    private final List<File> templateFiles;
+    private String suffixRegex;
+    private boolean failOnError;
+
+    public JavaGeneratorRunnable() {
+        this.configuration = new RockerConfiguration();
+        this.parser = new TemplateParser(this.configuration);
+        this.generator = new JavaGenerator(this.configuration);
+        this.templateFiles = new ArrayList<>();
+        this.suffixRegex = ".*\\.rocker\\.(raw|html)$";
+        this.failOnError = true;
+    }
+
+    public String getSuffixRegex() {
+        return suffixRegex;
+    }
+
+    public void setSuffixRegex(String suffixRegex) {
+        this.suffixRegex = suffixRegex;
+    }
+
+    public boolean isFailOnError() {
+        return failOnError;
+    }
+
+    public void setFailOnError(boolean failOnError) {
+        this.failOnError = failOnError;
+    }
+
+    public TemplateParser getParser() {
+        return parser;
+    }
+
+    public JavaGenerator getGenerator() {
+        return generator;
+    }
+
+    public void run() throws RuntimeException{
+        if (this.configuration.getTemplateDirectory() == null) {
+            throw new RuntimeException("Template directory was null");
+        }
+
+        if (!this.configuration.getTemplateDirectory().exists() || !this.configuration.getTemplateDirectory().isDirectory()) {
+            throw new RuntimeException("Template directory does not exist: " + this.configuration.getTemplateDirectory());
+        }
+
+        // loop thru template directory and match templates
+        Collection<File> allFiles = RockerUtil.listFileTree(this.configuration.getTemplateDirectory());
+        for (File f : allFiles) {
+            if (f.getName().matches(suffixRegex)) {
+                templateFiles.add(f);
+            }
+        }
+
+        log.info("Parsing " + templateFiles.size() + " rocker template files");
+
+        int errors = 0;
+        int generated = 0;
+
+        for (File f : templateFiles) {
+            TemplateModel model = null;
+
+            try {
+                // parse model
+                model = parser.parse(f);
+            } catch (IOException | ParserException e) {
+                if (e instanceof ParserException) {
+                    ParserException pe = (ParserException) e;
+                    log.error("Parsing failed for " + f + ":[" + pe.getLineNumber() + "," + pe.getColumnNumber() + "] " + pe.getMessage());
+                } else {
+                    log.error("Unable to parse template", e);
+                }
+                errors++;
+            }
+
+            try {
+                File outputFile = generator.generate(model);
+                generated++;
+
+                log.debug("Generated java source: " + outputFile);
+            } catch (GeneratorException | IOException e) {
+                throw new RuntimeException("Generating java source failed for " + f + ": " + e.getMessage(), e);
+            }
+
+        }
+
+        log.info("Generated " + generated + " rocker java source files");
+
+        if (errors > 0 && failOnError) {
+            throw new RuntimeException("Caught " + errors + " errors.");
+        }
+
+        if (!configuration.getOptions().getOptimize()) {
+            // save configuration
+            this.configuration.getClassDirectory().mkdirs();
+
+            // use resource name, but strip leading slash
+            // place it into the classes directory (not the compile directory)
+            try{
+                File configFile = new File(this.configuration.getClassDirectory(), RockerRuntime.CONF_RESOURCE_NAME.substring(1));
+                this.configuration.write(configFile);
+                log.info("Generated rocker configuration " + configFile);
+            }catch(IOException iox){
+                throw new RuntimeException(iox);
+            }
+        } else {
+            log.info("Optimize flag on. Did not generate rocker configuration file");
+        }
+    }
+
+    public void setTemplateDirectory(File templateDirectory) {
+        this.parser.getConfiguration().setTemplateDirectory(templateDirectory);
+    }
+
+    public void setOutputDirectory(File outputDirectory) {
+        this.generator.getConfiguration().setOutputDirectory(outputDirectory);
+    }
+}

--- a/rocker-maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
+++ b/rocker-maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
@@ -1,9 +1,6 @@
 package com.fizzed.rocker.maven;
 
-import com.fizzed.rocker.compiler.JavaGeneratorMain;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import com.fizzed.rocker.compiler.JavaGeneratorRunnable;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -12,6 +9,10 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 /**
  * Maven plugin for parsing Rocker templates and generating Java source code.
@@ -120,41 +121,41 @@ public class GenerateMojo extends AbstractMojo {
         }
         
         try {
-            JavaGeneratorMain jgm = new JavaGeneratorMain();
+            JavaGeneratorRunnable jgr = new JavaGeneratorRunnable();
             
-            jgm.getParser().getConfiguration().setTemplateDirectory(templateDirectory);
-            jgm.getGenerator().getConfiguration().setOutputDirectory(outputDirectory);
-            jgm.getGenerator().getConfiguration().setClassDirectory(classDirectory);
-            //jgm.getGenerator().getConfiguration().setCompileDirectory(compileDirectory);
-            jgm.setFailOnError(failOnError);
+            jgr.getParser().getConfiguration().setTemplateDirectory(templateDirectory);
+            jgr.getGenerator().getConfiguration().setOutputDirectory(outputDirectory);
+            jgr.getGenerator().getConfiguration().setClassDirectory(classDirectory);
+            //jgr.getGenerator().getConfiguration().setCompileDirectory(compileDirectory);
+            jgr.setFailOnError(failOnError);
             
             // passthru other config
             if (suffixRegex != null) {
-                jgm.setSuffixRegex(suffixRegex);
+                jgr.setSuffixRegex(suffixRegex);
             }
             if (javaVersion != null) {
-                jgm.getParser().getConfiguration().getOptions().setJavaVersion(javaVersion);
+                jgr.getParser().getConfiguration().getOptions().setJavaVersion(javaVersion);
             }
             if (extendsClass != null) {
-                jgm.getParser().getConfiguration().getOptions().setExtendsClass(extendsClass);
+                jgr.getParser().getConfiguration().getOptions().setExtendsClass(extendsClass);
             }
             if (extendsModelClass != null) {
-                jgm.getParser().getConfiguration().getOptions().setExtendsModelClass(extendsModelClass);
+                jgr.getParser().getConfiguration().getOptions().setExtendsModelClass(extendsModelClass);
             }
             if (discardLogicWhitespace != null) {
-                jgm.getParser().getConfiguration().getOptions().setDiscardLogicWhitespace(discardLogicWhitespace);
+                jgr.getParser().getConfiguration().getOptions().setDiscardLogicWhitespace(discardLogicWhitespace);
             }
             if (targetCharset != null) {
-                jgm.getParser().getConfiguration().getOptions().setTargetCharset(targetCharset);
+                jgr.getParser().getConfiguration().getOptions().setTargetCharset(targetCharset);
             }
             if (optimize != null) {
-                jgm.getParser().getConfiguration().getOptions().setOptimize(optimize);
+                jgr.getParser().getConfiguration().getOptions().setOptimize(optimize);
             }
             if (postProcessing != null ) {
-            	jgm.getParser().getConfiguration().getOptions().setPostProcessing(postProcessing);
+            	jgr.getParser().getConfiguration().getOptions().setPostProcessing(postProcessing);
             }
             
-            jgm.run();
+            jgr.run();
         }
         catch (Exception e) {
             throw new MojoExecutionException(e.getMessage(), e);


### PR DESCRIPTION
To make it easy to run the Rocker template generator programmatically, I've extracted most of the logic of JavaGeneratorMain into a separate class that implements Runnable. 
The main motivation here for me, is to allow using this generator together with the new Worker API in Gradle that expects a Runnable. Also splitting up the console logic in JavaGenerator from the actual runner is an improvement IMO. 