### PR TITLE
Add support for Java 9

### DIFF
--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.util.*;
 
 import static com.fizzed.rocker.compiler.RockerUtil.*;
-import javax.annotation.Generated;
 
 public class JavaGenerator {
     static private final Logger log = LoggerFactory.getLogger(JavaGenerator.class);
@@ -169,7 +168,6 @@ public class JavaGenerator {
        
         // imports regardless of template
         w.append(CRLF);
-        w.append("import ").append(Generated.class.getName()).append(";").append(CRLF);
         w.append("import ").append(java.io.IOException.class.getName()).append(";").append(CRLF);
         w.append("import ").append(com.fizzed.rocker.ForIterator.class.getName()).append(";").append(CRLF);
         w.append("import ").append(com.fizzed.rocker.RenderingException.class.getName()).append(";").append(CRLF);
@@ -202,7 +200,7 @@ public class JavaGenerator {
         // MODEL CLASS
         
         // annotations (https://github.com/fizzed/rocker/issues/59)
-        tab(w, indent).append("@Generated(\"com.fizzed.rocker.compiler.JavaGenerator\") @SuppressWarnings(\"unused\")")
+        tab(w, indent).append("@SuppressWarnings(\"unused\")")
             .append(CRLF);
         
         // class definition

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/TemplateCompiler.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/TemplateCompiler.java
@@ -107,8 +107,17 @@ public class TemplateCompiler {
 
         // under maven or other build tools, java.class.path is wrong
         // build our own from current context
+        // todo: there doesn't seem to be any test checking this assumption is correct.
         StringBuilder classpath = new StringBuilder();
-        URL[] classpathUrls = ((URLClassLoader)(Thread.currentThread().getContextClassLoader())).getURLs();
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+
+        // starting in java 9, the class loader isn't necessarily an instance of URLClassLoader
+        URL[] classpathUrls = new URL[0];
+        if (contextClassLoader instanceof URLClassLoader) {
+            classpathUrls = ((URLClassLoader) contextClassLoader).getURLs();
+        } else {
+            classpath.append(System.getProperty("java.class.path"));
+        }
         for (URL url : classpathUrls) {
             if (classpath.length() > 0) {
                 classpath.append(File.pathSeparator);

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVersion.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVersion.java
@@ -23,8 +23,10 @@ public enum JavaVersion {
     
     v1_6 (6, "1.6"),
     v1_7 (7, "1.7"),
-    v1_8 (8, "1.8");
-    
+    v1_8 (8, "1.8"),
+    V9   (9, "9"),
+    ;
+
     private final int version;
     private final String label;
     

--- a/rocker-maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
+++ b/rocker-maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
@@ -114,7 +114,18 @@ public class GenerateMojo extends AbstractMojo {
         
         if (javaVersion == null || javaVersion.length() == 0) {
             // set to current jdk version
-            javaVersion = System.getProperty("java.version").substring(0, 3);
+            String version = System.getProperty("java.version");
+            if (version.startsWith("1.")) {
+                javaVersion = version.substring(0, 3);
+            } else {
+                try {
+                    // javaVersion = String.valueOf(Runtime.version().major());
+                    Object runtimeVersion = Runtime.class.getMethod("version").invoke(null);
+                    javaVersion = runtimeVersion.getClass().getMethod("major").invoke(runtimeVersion).toString();
+                } catch (Exception e) {
+                    throw new MojoExecutionException("Could not infer java version, set the rocker.javaVersion property manually to fix this problem", e);
+                }
+            }
             getLog().info("Property rocker.javaVersion not set. Using your JDK version " + this.javaVersion);
         } else {
             getLog().info("Targeting java version " + this.javaVersion);


### PR DESCRIPTION
Remove @Generated annotation as it's broken in java 9+
Fall back to java.class.path property when Thread#getContextClassLoader doesn't return an URLClassLoader
Handle major version 9

Fixes #73