### PR TITLE
Add JDK10 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.7.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVersion.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVersion.java
@@ -25,7 +25,7 @@ public enum JavaVersion {
     v1_7 (7, "1.7"),
     v1_8 (8, "1.8"),
     V9   (9, "9"),
-    ;
+    V10  (10, "10");
 
     private final int version;
     private final String label;


### PR DESCRIPTION
Currently using Java 10 and above results in the following error:
```
[ERROR] Failed to execute goal com.fizzed:rocker-maven-plugin:0.24.0:generate (generate-rocker-templates) on project market: Unsupported javaVersion [10] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```
Rocker seems to run w/o a problem on higher Java versions, as long as you lie in the `rocker.javaVersion` inside your pom, so I've just added two new entries to the JavaVersion enum.

~~Beside that, I've added JDK10 and JDK11 to the travis.yml, in a manner similar e.g. to JUnit: https://github.com/junit-team/junit5/blob/master/.travis.yml
Looks to be working fine in my fork - https://travis-ci.org/drauf/rocker/builds/369527455~~