### PR TITLE
Fix incremental java compilation with rocker and Gradle

### DIFF
--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
@@ -215,25 +215,25 @@ public class JavaGenerator {
         w.append(CRLF);
         
         // static info about this template
-        tab(w, indent).append("static public final ")
-                .append(ContentType.class.getCanonicalName()).append(" CONTENT_TYPE = ")
-                .append(ContentType.class.getCanonicalName()).append(".").append(model.getContentType().toString()).append(";").append(CRLF);
-        tab(w, indent).append("static public final String TEMPLATE_NAME = \"").append(model.getTemplateName()).append("\";").append(CRLF);
-        tab(w, indent).append("static public final String TEMPLATE_PACKAGE_NAME = \"").append(model.getPackageName()).append("\";").append(CRLF);
-        tab(w, indent).append("static public final String HEADER_HASH = \"").append(model.createHeaderHash()+"").append("\";").append(CRLF);
+        tab(w, indent).append("static public ")
+                .append(ContentType.class.getCanonicalName()).append(" getContentType() { return ")
+                .append(ContentType.class.getCanonicalName()).append(".").append(model.getContentType().toString()).append("; }").append(CRLF);
+        tab(w, indent).append("static public String getTemplateName() { return \"").append(model.getTemplateName()).append("\"; }").append(CRLF);
+        tab(w, indent).append("static public String getTemplatePackageName() { return \"").append(model.getPackageName()).append("\"; }").append(CRLF);
+        tab(w, indent).append("static public String getHeaderHash() { return \"").append(model.createHeaderHash()+"").append("\"; }").append(CRLF);
 
-        // Don't include MODIFIED_AT header when optimized compiler is used since this implicitly disables hot reloading anyhow
+        // Don't include getModifiedAt header when optimized compiler is used since this implicitly disables hot reloading anyhow
         if (!model.getOptions().getOptimize()) {
-            tab(w, indent).append("static public final long MODIFIED_AT = ").append(model.getModifiedAt() + "").append("L;").append(CRLF);
+            tab(w, indent).append("static public long getModifiedAt() { return ").append(model.getModifiedAt() + "").append("L; }").append(CRLF);
         }
 
-        tab(w, indent).append("static public final String[] ARGUMENT_NAMES = {");
+        tab(w, indent).append("static public String[] getArgumentNames() { return new String[] {");
         StringBuilder argNameList = new StringBuilder();
         for (Argument arg : model.getArgumentsWithoutRockerBody()) {
             if (argNameList.length() > 0) { argNameList.append(","); }
             argNameList.append(" \"").append(arg.getExternalName()).append("\"");
         }
-        w.append(argNameList).append(" };").append(CRLF);
+        w.append(argNameList).append(" }; }").append(CRLF);
         
 
         // model arguments as members of model class
@@ -423,9 +423,9 @@ public class JavaGenerator {
         
         tab(w, indent+1).append("super(model);").append(CRLF);
         tab(w, indent+1).append("__internal.setCharset(\"").append(model.getOptions().getTargetCharset()).append("\");").append(CRLF);
-        tab(w, indent+1).append("__internal.setContentType(CONTENT_TYPE);").append(CRLF);
-        tab(w, indent+1).append("__internal.setTemplateName(TEMPLATE_NAME);").append(CRLF);
-        tab(w, indent+1).append("__internal.setTemplatePackageName(TEMPLATE_PACKAGE_NAME);").append(CRLF);
+        tab(w, indent+1).append("__internal.setContentType(getContentType());").append(CRLF);
+        tab(w, indent+1).append("__internal.setTemplateName(getTemplateName());").append(CRLF);
+        tab(w, indent+1).append("__internal.setTemplatePackageName(getTemplatePackageName());").append(CRLF);
         
         // each model argument passed along as well
         for (Argument arg : model.getArguments()) {

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/reload/ReloadingRockerBootstrap.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/reload/ReloadingRockerBootstrap.java
@@ -31,6 +31,8 @@ import com.fizzed.rocker.runtime.DefaultRockerTemplate;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -98,37 +100,37 @@ public class ReloadingRockerBootstrap extends DefaultRockerBootstrap {
     
     private long getModelClassModifiedAt(Class modelType) throws RenderingException {
         try {
-            Field f = modelType.getField("MODIFIED_AT");
-            return f.getLong(null);
-        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
-            throw new RenderingException("Unable to read MODIFIED_AT static field from class " + modelType.getName());
+            Method m = modelType.getMethod("getModifiedAt");
+            return (long) m.invoke(null);
+        } catch (SecurityException | IllegalArgumentException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            throw new RenderingException("Unable to read getModifiedAt static method from class " + modelType.getName());
         }
     }
     
     private String getModelClassHeaderHash(Class modelType) throws RenderingException {
         try {
-            Field f = modelType.getField("HEADER_HASH");
-            return (String)f.get(null);
-        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
-            throw new RenderingException("Unable to read HEADER_HASH static field from class " + modelType.getName());
+            Method m = modelType.getMethod("getHeaderHash");
+            return (String)m.invoke(null);
+        } catch (NoSuchMethodException | SecurityException | IllegalArgumentException | IllegalAccessException | InvocationTargetException e) {
+            throw new RenderingException("Unable to read getHeaderHash static method from class " + modelType.getName());
         }
     }
     
     private String getModelClassTemplatePackageName(Class modelType) throws RenderingException {
         try {
-            Field f = modelType.getField("TEMPLATE_PACKAGE_NAME");
-            return (String)f.get(null);
-        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
-            throw new RenderingException("Unable to read TEMPLATE_PACKAGE_NAME static field from class " + modelType.getName());
+            Method m = modelType.getMethod("getTemplatePackageName");
+            return (String)m.invoke(null);
+        } catch (SecurityException | IllegalArgumentException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            throw new RenderingException("Unable to read getTemplatePackageName static method from class " + modelType.getName());
         }
     }
     
     private String getModelClassTemplateName(Class modelType) throws RenderingException {
         try {
-            Field f = modelType.getField("TEMPLATE_NAME");
-            return (String)f.get(null);
-        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
-            throw new RenderingException("Unable to read TEMPLATE_NAME static field from class " + modelType.getName());
+            Method m = modelType.getMethod("getTemplateName");
+            return (String)m.invoke(null);
+        } catch (SecurityException | IllegalArgumentException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new RenderingException("Unable to read getTemplateName static method from class " + modelType.getName());
         }
     }
     

--- a/rocker-compiler/src/test/resources/generated/Args.java.txt
+++ b/rocker-compiler/src/test/resources/generated/Args.java.txt
@@ -14,11 +14,11 @@ import com.fizzed.rocker.runtime.PlainTextUnloadedClassLoader;
  */
 public class Args extends com.fizzed.rocker.runtime.DefaultRockerModel {
 
-    static public final com.fizzed.rocker.ContentType CONTENT_TYPE = com.fizzed.rocker.ContentType.HTML;
-    static public final String TEMPLATE_NAME = "Args.rocker.html";
-    static public final String TEMPLATE_PACKAGE_NAME = "rocker";
-    static public final String HEADER_HASH = "379218683";
-    static public final long MODIFIED_AT = 1442956658000L;
+    static public com.fizzed.rocker.ContentType getContentType() { return com.fizzed.rocker.ContentType.HTML; }
+    static public String getTemplateName() { return "Args.rocker.html"; }
+    static public String getTemplatePackageName() { return "rocker"; }
+    static public String getHeaderHash() = { return "379218683"; }
+    static public long getModifiedAt() { return 1442956658000L; }
 
     // argument @ [4:6]
     private String s;

--- a/rocker-runtime/src/main/java/com/fizzed/rocker/Rocker.java
+++ b/rocker-runtime/src/main/java/com/fizzed/rocker/Rocker.java
@@ -17,6 +17,7 @@ package com.fizzed.rocker;
 
 import com.fizzed.rocker.runtime.RockerRuntime;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 /**
  *
@@ -70,10 +71,10 @@ public class Rocker {
     
     static private String[] getModelArgumentNames(String templatePath, RockerModel model) {
         try {
-            Field f = model.getClass().getField("ARGUMENT_NAMES");
-            return (String[])f.get(null);
+            Method f = model.getClass().getMethod("getArgumentNames");
+            return (String[])f.invoke(null);
         } catch (Exception e) {
-            throw new TemplateBindException(templatePath, model.getClass().getCanonicalName(), "Unable to read ARGUMENT_NAMES static field from template");
+            throw new TemplateBindException(templatePath, model.getClass().getCanonicalName(), "Unable to read getModifiedAt static method from template");
         }
     }
     

--- a/rocker-test-java6/src/test/java/com/fizzed/rocker/compiler/CompiledTemplateTest.java
+++ b/rocker-test-java6/src/test/java/com/fizzed/rocker/compiler/CompiledTemplateTest.java
@@ -917,8 +917,8 @@ public class CompiledTemplateTest {
         assertThat(html, is("b"));
     }
 
-    @Test(expected = NoSuchFieldException.class)
+    @Test(expected = NoSuchMethodException.class)
     public void optmizedCompilerOmitsModifedAtHeader() throws Exception {
-        rocker.A.class.getField("MODIFIED_AT");
+        rocker.A.class.getMethod("getModifiedAt");
     }
 }


### PR DESCRIPTION
- Replace public static constant fields with static methods in the template classes

This is a fix for https://github.com/fizzed/rocker/issues/88

I've tested the incremental compilation manually and now it works as expected without forcing gradle to recompile everything everytime a template class has changed.

I'm looking forward to your feedback. all tests passed locally for me.  