### PR TITLE
Handle autodetection of Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 jdk:
+  - openjdk7
   - oraclejdk8
   - oraclejdk9
-  - openjdk7
+  - openjdk10
+  - openjdk11

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVersion.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVersion.java
@@ -15,21 +15,21 @@
  */
 package com.fizzed.rocker.model;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  *
  * @author joelauer
  */
 public enum JavaVersion {
-    
+
     v1_6 (6, "1.6"),
     v1_7 (7, "1.7"),
-    v1_8 (8, "1.8"),
-    V9   (9, "9"),
-    V10  (10, "10");
+    v1_8 (8, "1.8");
 
     private final int version;
     private final String label;
-    
+
     JavaVersion(int version, String label) {
         this.version = version;
         this.label = label;
@@ -42,8 +42,14 @@ public enum JavaVersion {
     public String getLabel() {
         return label;
     }
-    
+
     static public JavaVersion findByLabel(String label) {
+        // starting from Java 9, the version is simply a number, i.e. 9, 10, 11, and so on
+        // we select the best minimum compatible level for those Java versions
+        if (StringUtils.isNumeric(label)) {
+            return v1_8;
+        }
+
         for (JavaVersion jv : JavaVersion.values()) {
             if (jv.getLabel().equals(label)) {
                 return jv;
@@ -51,5 +57,5 @@ public enum JavaVersion {
         }
         return null;
     }
-    
+
 }


### PR DESCRIPTION
https://travis-ci.org/drauf/rocker/builds/437732529

closes #90 
This adds a _MODERN_ value to the JavaVersion enum, that all Java versions after 9 will be assigned to.

In the code the value of this enum is only used in five places:
- twice to assert if the JVM running is at least Java 8 (the _int version_)
- once in an error message (the _String label_)
- twice to serialize and deserialize config (the _String label_)

The config serialization won't break after removing the two options from the enum, because they will still be parsed as the _MODERN_ value.