### PR TITLE
Proper parsing type attribute in JavaVariable

### DIFF
--- a/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVariable.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVariable.java
@@ -45,8 +45,8 @@ public class JavaVariable {
         if (type == null) {
             this.type = null;
         } else {
-            // remove all whitespace
-            this.type = type.replaceAll(" ", "");
+            // remove all unnecessary whitespaces
+            this.type = type.replaceAll("(?<!extends|super)\\s+(?!extends|super)", "");
         }
         this.name = name;
     }

--- a/rocker-compiler/src/test/java/com/fizzed/rocker/model/JavaVariableTest.java
+++ b/rocker-compiler/src/test/java/com/fizzed/rocker/model/JavaVariableTest.java
@@ -10,7 +10,7 @@ import java.util.List;
  * @author joelauer
  */
 public class JavaVariableTest {
-    
+
     @Test
     public void parseToken() throws Exception {
 
@@ -112,7 +112,7 @@ public class JavaVariableTest {
         // simple types
         vars = JavaVariable.parseList("User u, String s");
 
-	Assert.assertEquals(2, vars.size());
+        Assert.assertEquals(2, vars.size());
         Assert.assertEquals(new JavaVariable("User", "u"), vars.get(0));
         Assert.assertEquals(new JavaVariable("String", "s"), vars.get(1));
 
@@ -164,6 +164,44 @@ public class JavaVariableTest {
         Assert.assertEquals(1, vars.size());
         Assert.assertEquals(new JavaVariable("java.lang.String  [  ] [  ]", "s"), vars.get(0));
         Assert.assertEquals("java.lang.String[][]", vars.get(0).getType());
-        
+
+    }
+
+    @Test
+    public void type_shouldBeParsedWithLeastWhitespacesAsPossible() {
+        final String unimportant = "foos";
+        final JavaVariable genericCollectionOfExtensions = new JavaVariable("Collection<? extends Foo>", unimportant);
+        final JavaVariable genericCollectionOfExtensionsWithLootsOfWhitespaces = new JavaVariable(
+                "    Collection\t     <    ?\t  extends    Foo     >   ", unimportant
+        );
+        final JavaVariable genericCollectionOfAncestorsWithLootsOfWhitespaces = new JavaVariable(
+                "    Collection\t     <    ?\t  super    Foo     >   ", unimportant
+        );
+        final JavaVariable complexFunctionWithLootsOfWhitespaces = new JavaVariable(
+                "      Function    <\t   ?    extends    Foo,     ?   super    \tBar  >   ", unimportant
+        );
+        final JavaVariable genericCollectionOfExtensionsWithFullyQualifiedClassNameAndLootsOfWhitespaces =
+                new JavaVariable(
+                        "   Collection  <  ? extends some   .  fancy. \t package   .Foo    > \n  ", unimportant
+                );
+        final JavaVariable genericCollectionOfFoosWithLootsOfWhitespaces = new JavaVariable(
+                "   Collection  < \tFoo    >  ", unimportant
+        );
+        final JavaVariable fooTypeWithLootsOfWhitespaces = new JavaVariable("  \t  Foo \t    ", unimportant);
+        final JavaVariable arrayOfFooWithLootsOfWhitespaces = new JavaVariable("    Foo  [ \t ]   ", unimportant);
+        final JavaVariable arrayOfSimpleIntTypeWithLootsOfWhitespaces = new JavaVariable(" \t  int  [  ] \t ", unimportant);
+
+        Assert.assertEquals("Collection<? extends Foo>", genericCollectionOfExtensions.getType());
+        Assert.assertEquals("Collection<? extends Foo>", genericCollectionOfExtensionsWithLootsOfWhitespaces.getType());
+        Assert.assertEquals("Collection<? super Foo>", genericCollectionOfAncestorsWithLootsOfWhitespaces.getType());
+        Assert.assertEquals("Function<? extends Foo,? super Bar>", complexFunctionWithLootsOfWhitespaces.getType());
+        Assert.assertEquals(
+                "Collection<? extends some.fancy.package.Foo>",
+                genericCollectionOfExtensionsWithFullyQualifiedClassNameAndLootsOfWhitespaces.getType()
+        );
+        Assert.assertEquals("Collection<Foo>", genericCollectionOfFoosWithLootsOfWhitespaces.getType());
+        Assert.assertEquals("Foo", fooTypeWithLootsOfWhitespaces.getType());
+        Assert.assertEquals("Foo[]", arrayOfFooWithLootsOfWhitespaces.getType());
+        Assert.assertEquals("int[]", arrayOfSimpleIntTypeWithLootsOfWhitespaces.getType());
     }
 }


### PR DESCRIPTION
@jjlauer as far as I’m concerned in this case fix in parsing types in `JavaVariable` will be enough. It is done in this pull request. Please check it out. I will be pleased if you let me know what you think about it. Especially about tests, and naming convention, because I personally prefer more meaningful, and straightforward names, but if you do not want consider introduce this style in your code in future then I think that it will be better to have less meaningful, but uniform names :)

Talking about ANTLR grammar. I’m not expert but (in my opinion) change is not necessary in this case because everything in `@args()` section is matched by `MV_ARGS` token. But for other purposes it could be helpful to investigate more in  ANTLR grammar parts like `TypeArgument` fragment.

BTW when do you plan to release new version of rocker? :)