### PR TITLE
Fix #106 SLF4J unnecessary initialization

### DIFF
--- a/rocker-runtime/src/main/java/com/fizzed/rocker/runtime/RockerRuntime.java
+++ b/rocker-runtime/src/main/java/com/fizzed/rocker/runtime/RockerRuntime.java
@@ -81,10 +81,7 @@ public class RockerRuntime {
         }
         if (logging) {
             log = LoggerFactory.getLogger(RockerRuntime.class);
-            if (this.logging == null) {
-                //Log the version only once but log it if logging is turned on after instantiation
-                log.info("Rocker version {}", com.fizzed.rocker.Version.getVersion());
-            }
+            log.info("Rocker version {}", com.fizzed.rocker.Version.getVersion());
         }
         else {
             log = NOPLogger.NOP_LOGGER;


### PR DESCRIPTION
This was the easiest solution I could think of and is consistent with the existing paradigm of bootstrap config but has an assumption that logging will only be done in the RockerRuntime class.

A more sophisticated solution would be to use my gist and then have some sort of code checker to check for calls to LoggerFactory.getLogger() and error.

Without the code checker and the fact that logging is barely used I didn't deem it worth the effort to add the wrapper.

EDIT gist being: https://gist.github.com/agentgt/28dc6e9724cb8b96ca08fc147476a7de