### PR TITLE
Mark generated classes as generated #116

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,11 @@ to Rocker's default value.
     parse.
     Defaults to Rocker's default.
 
+ * `markAsGenerated` adds a @Generated annotation to the generated classes.
+    The Retention is CLASS so that the annotation can be used by tools that
+    only rely on the class files and not on the source code.
+    Defaults to Rocker's default.
+
 #### Gradle
 
 Thanks to `@victory` and `@mnlipp` for contributing the gradle plugin. `@etiennestuder`
@@ -487,6 +492,7 @@ rocker {
     targetCharset null
     suffixRegex null
     postProcessing null
+    markAsGenerated null
 }
 
 ```

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/JavaGenerator.java
@@ -15,6 +15,7 @@
  */
 package com.fizzed.rocker.compiler;
 import com.fizzed.rocker.ContentType;
+import com.fizzed.rocker.Generated;
 import com.fizzed.rocker.RockerContent;
 import com.fizzed.rocker.model.*;
 import com.fizzed.rocker.runtime.*;
@@ -202,6 +203,10 @@ public class JavaGenerator {
         // annotations (https://github.com/fizzed/rocker/issues/59)
         tab(w, indent).append("@SuppressWarnings(\"unused\")")
             .append(CRLF);
+
+        if (model.getOptions().getMarkAsGenerated()) {
+            tab(w, indent).append('@').append(Generated.class.getCanonicalName()).append(CRLF);
+        }
         
         // class definition
         tab(w, indent).append("public class ")
@@ -327,6 +332,9 @@ public class JavaGenerator {
         
         w.append(CRLF);
         
+        if (model.getOptions().getMarkAsGenerated()) {
+            tab(w, indent).append('@').append(Generated.class.getCanonicalName()).append(CRLF);
+        }
         // class definition
         tab(w, indent)
             .append("static public class Template extends ")
@@ -978,6 +986,9 @@ public class JavaGenerator {
             
             w.append(CRLF);
             
+            if (model.getOptions().getMarkAsGenerated()) {
+                tab(w, indent).append('@').append(Generated.class.getCanonicalName()).append(CRLF);
+            }
             tab(w, indent).append("private static class PlainText {").append(CRLF);
             w.append(CRLF);
             

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/RockerOptions.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/compiler/RockerOptions.java
@@ -39,6 +39,7 @@ public class RockerOptions {
     static public final String TARGET_CHARSET = "targetCharset";
     static public final String OPTIMIZE = "optimize";
     static public final String POST_PROCESSING = "postProcessing";
+    static public final String MARK_AS_GENERATED = "markAsGenerated";
     
     // generated source compatiblity
     private JavaVersion javaVersion;
@@ -57,6 +58,8 @@ public class RockerOptions {
     private Boolean optimize;
     // names of classes to be used for post-processing the model in order of appearance
     private String[] postProcessing;
+    // mark generated classes with @Generated
+    private Boolean markAsGenerated;
     
     public RockerOptions() {
         this.javaVersion = JavaVersion.v1_8;
@@ -67,6 +70,7 @@ public class RockerOptions {
         this.targetCharset = "UTF-8";
         this.optimize = Boolean.FALSE;
         this.postProcessing = new String[0];
+        this.markAsGenerated = Boolean.FALSE;
     }
     
     public RockerOptions copy() {
@@ -81,6 +85,7 @@ public class RockerOptions {
         // do not copy post-processor class names from global configuration.
         // these need to be kept separate from per-template configurations.
         options.postProcessing = new String[0];
+        options.markAsGenerated = this.markAsGenerated;
         return options;
     }
 
@@ -168,6 +173,14 @@ public class RockerOptions {
         this.optimize = optimize;
     }
 
+    public Boolean getMarkAsGenerated() {
+        return markAsGenerated;
+    }
+
+    public void setMarkAsGenerated(Boolean markAsGenerated) {
+        this.markAsGenerated = markAsGenerated;
+    }
+
     public String[] getPostProcessing() {
     	return postProcessing;
     }
@@ -205,6 +218,9 @@ public class RockerOptions {
             case POST_PROCESSING:
             	this.setPostProcessing(parseStringArrayFromList(optionValue));
             	break;
+            case MARK_AS_GENERATED:
+                this.setMarkAsGenerated(parseBoolean(optionValue));
+                break;
             default:
                 throw new TokenException("Invalid option (" + optionName + ") is not a property)");
         }
@@ -228,6 +244,9 @@ public class RockerOptions {
         properties.put(RockerConfiguration.OPTION_PREFIX + TARGET_CHARSET, this.targetCharset);
         if (this.postProcessing != null && postProcessing.length != 0) {
             properties.put(RockerConfiguration.OPTION_PREFIX + POST_PROCESSING, StringUtils.join(this.postProcessing,","));
+        }
+        if (this.markAsGenerated != null) {
+            properties.put(RockerConfiguration.OPTION_PREFIX + MARK_AS_GENERATED, this.markAsGenerated.toString());
         }
     }
     

--- a/rocker-gradle-plugin/src/main/java/com/fizzed/rocker/gradle/RockerConfiguration.java
+++ b/rocker-gradle-plugin/src/main/java/com/fizzed/rocker/gradle/RockerConfiguration.java
@@ -28,6 +28,7 @@ public class RockerConfiguration {
     private File outputBaseDirectory;
     private File classBaseDirectory;
     private String[] postProcessing;
+    private Boolean markAsGenerated;
 
     public RockerConfiguration(Project project) {
 		super();
@@ -175,5 +176,15 @@ public class RockerConfiguration {
 
     public void setPostProcessing(String[] postProcessing) {
         this.postProcessing = postProcessing;
+    }
+
+    @Optional
+    @Input
+    public Boolean getMarkAsGenerated() {
+        return markAsGenerated;
+    }
+
+    public void setMarkAsGenerated(Boolean markAsGenerated) {
+        this.markAsGenerated = markAsGenerated;
     }
 }

--- a/rocker-gradle-plugin/src/main/java/com/fizzed/rocker/gradle/RockerTask.java
+++ b/rocker-gradle-plugin/src/main/java/com/fizzed/rocker/gradle/RockerTask.java
@@ -185,6 +185,9 @@ public class RockerTask extends DefaultTask {
             if (ext.getPostProcessing() != null ) {
                 rockerOptions.setPostProcessing(ext.getPostProcessing());
             }
+            if (ext.getMarkAsGenerated() != null) {
+                rockerOptions.setMarkAsGenerated(ext.getMarkAsGenerated());
+            }
 
             jgm.run();
 

--- a/rocker-maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
+++ b/rocker-maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
@@ -86,6 +86,12 @@ public class GenerateMojo extends AbstractMojo {
     
     @Parameter( property = "rocker.postProcessing", required = false)
     protected String[] postProcessing;
+
+    /**
+     * Weather or not to mark the generated classes as {@code @Generated}. 
+     * */
+    @Parameter(property = "rocker.markAsGenerated")
+    protected Boolean markAsGenerated;
     
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -164,6 +170,9 @@ public class GenerateMojo extends AbstractMojo {
             }
             if (postProcessing != null ) {
             	jgr.getParser().getConfiguration().getOptions().setPostProcessing(postProcessing);
+            }
+            if (markAsGenerated != null) {
+                jgr.getParser().getConfiguration().getOptions().setMarkAsGenerated(markAsGenerated);
             }
             
             jgr.run();

--- a/rocker-runtime/src/main/java/com/fizzed/rocker/Generated.java
+++ b/rocker-runtime/src/main/java/com/fizzed/rocker/Generated.java
@@ -1,0 +1,19 @@
+/**
+ * 
+ */
+package com.fizzed.rocker;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the class as generated for tools like JaCoCo.
+ * */
+@Documented
+@Retention(CLASS)
+@Target(TYPE)
+public @interface Generated {}


### PR DESCRIPTION
@jjlauer this is my initial attempt at #116.

I haven't made the feature configurable yet, because there is something I want to discuss first.

My intention was to apply the annotation to every class rocker generates. The catch is, that rocker generates:
 * anonymous classes for java 6 and 7
 * lambas for java 8

Right now java does not allow annotations on either of them.

For anonymous classes there might be a solution in the form of JSR308 (Introduced in java 8).

```java
callMethod(new @Generated AnonymousClass(){})
```

But this also has it's problems:

 1. I don't think JaCoCo supports JSR308 annotations.
 2. This only works for anonymous classes. Those are only generated by rocker on the <8 java profile. But JSR308 requires at least java 8.

Those are the options we have in the order my preference:

**0: Promote the anonymous classes and lambdas to proper classes**
Let's generate the problematic classes as `static` inner classes that can be annotated.

Pros:
 * Only rocker code changes required.
 * Completely solves the problem. JaCoCo works now.

Cons:
 * This is a rather big change.

**1: Ask JaCoCo to change**
We/I can ask JaCoCO to change their logic. They should ignore anonymous classes or lambdas inside of classes marked as `@Generated`.

Pros:
 * The rocker changes are kept minimal.
 * Seems like the right thing to me.

Cons:
 * Bigger coordination effort since 2 projects are now affected.

**2: Abandon the idea**
Let's do nothing and chill.

Pros:
 * Still better than 3 imo.

Cons:
 * My problem is not solved :(

**3: Use JSR308 annotations**
For java8 let's use JSR308 annotations. Remove the lambdas and replace them with anonymous classes.

Pros:
 * ?

Cons:
 * Changes in JaCoCo required.
 * Only works for java >8.
 * Combines the disadvantage of a big change as in 0, with none of it's advantages.