### PR TITLE
Obtain current Java version from system property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 language: java
+dist: trusty
 jdk:
   - openjdk7
-  - oraclejdk8
-  - oraclejdk9
+  - openjdk8
+  - openjdk9
   - openjdk10
-
-matrix:
-  include:
-    - jdk: openjdk11
-      before_install:
-        - rm "${JAVA_HOME}/lib/security/cacerts"
-        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+  - openjdk11

--- a/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVersion.java
+++ b/rocker-compiler/src/main/java/com/fizzed/rocker/model/JavaVersion.java
@@ -43,7 +43,7 @@ public enum JavaVersion {
         return label;
     }
 
-    static public JavaVersion findByLabel(String label) {
+    public static JavaVersion findByLabel(String label) {
         // starting from Java 9, the version is simply a number, i.e. 9, 10, 11, and so on
         // we select the best minimum compatible level for those Java versions
         if (StringUtils.isNumeric(label)) {
@@ -56,6 +56,20 @@ public enum JavaVersion {
             }
         }
         return null;
+    }
+
+    public static String current() {
+        return toVersion(System.getProperty("java.version"));
+    }
+
+    public static String toVersion(String version) {
+        if (version.startsWith("1.")) {
+            return version.substring(0, 3);
+        }
+
+        int dotIndex = version.indexOf('.');
+        int dashIndex = version.indexOf('-');
+        return version.substring(0, dotIndex > -1 ? dotIndex : dashIndex > -1 ? dashIndex : version.length());
     }
 
 }

--- a/rocker-compiler/src/test/java/com/fizzed/rocker/model/JavaVersionTest.java
+++ b/rocker-compiler/src/test/java/com/fizzed/rocker/model/JavaVersionTest.java
@@ -1,0 +1,36 @@
+package com.fizzed.rocker.model;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class JavaVersionTest {
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "1.6.0_23", "1.6"}, {"1.7.0", "1.7"}, {"1.7.0_80", "1.7"}, {"1.8.0_211", "1.8"}, {"9.0.7", "9"},
+                {"10.0.2", "10"}, {"11", "11"}, {"11.0.5", "11"}, {"12.0.1", "12"}, {"13.0.1", "13"}, {"14-ea", "14"}
+        });
+    }
+
+    private final String javaVersion;
+    private final String expectedVersion;
+
+    public JavaVersionTest(String javaVersion, String expectedVersion) {
+        this.javaVersion = javaVersion;
+        this.expectedVersion = expectedVersion;
+    }
+
+    @Test
+    public void shouldResolveToExpectedVersion() {
+        assertEquals(expectedVersion, JavaVersion.toVersion(javaVersion));
+    }
+
+}

--- a/rocker-gradle-plugin/src/main/java/com/fizzed/rocker/gradle/RockerTask.java
+++ b/rocker-gradle-plugin/src/main/java/com/fizzed/rocker/gradle/RockerTask.java
@@ -4,6 +4,7 @@ import com.fizzed.rocker.compiler.JavaGeneratorMain;
 import com.fizzed.rocker.compiler.JavaGeneratorRunnable;
 import com.fizzed.rocker.compiler.RockerOptions;
 
+import com.fizzed.rocker.model.JavaVersion;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
@@ -143,7 +144,7 @@ public class RockerTask extends DefaultTask {
 
         if (ext.getJavaVersion() == null || ext.getJavaVersion().length() == 0) {
             // set to current jdk version
-            ext.setJavaVersion(System.getProperty("java.version").substring(0, 3));
+            ext.setJavaVersion(JavaVersion.current());
             logInfo("Property rocker.javaVersion not set. Using your JDK version "
                 + ext.getJavaVersion());
         } else {

--- a/rocker-maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
+++ b/rocker-maven-plugin/src/main/java/com/fizzed/rocker/maven/GenerateMojo.java
@@ -1,6 +1,7 @@
 package com.fizzed.rocker.maven;
 
 import com.fizzed.rocker.compiler.JavaGeneratorRunnable;
+import com.fizzed.rocker.model.JavaVersion;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -120,18 +121,7 @@ public class GenerateMojo extends AbstractMojo {
         
         if (javaVersion == null || javaVersion.length() == 0) {
             // set to current jdk version
-            String version = System.getProperty("java.version");
-            if (version.startsWith("1.")) {
-                javaVersion = version.substring(0, 3);
-            } else {
-                try {
-                    // javaVersion = String.valueOf(Runtime.version().major());
-                    Object runtimeVersion = Runtime.class.getMethod("version").invoke(null);
-                    javaVersion = runtimeVersion.getClass().getMethod("major").invoke(runtimeVersion).toString();
-                } catch (Exception e) {
-                    throw new MojoExecutionException("Could not infer java version, set the rocker.javaVersion property manually to fix this problem", e);
-                }
-            }
+            javaVersion = JavaVersion.current();
             getLog().info("Property rocker.javaVersion not set. Using your JDK version " + this.javaVersion);
         } else {
             getLog().info("Targeting java version " + this.javaVersion);


### PR DESCRIPTION
Provides the correct Java version from System property `java.version`.
Applies same functionality for both Maven and Gradle plugins.
Fixes #120 