### PR TITLE
Add compatibility for Gradle 7 (Fix #143)

### DIFF
--- a/rocker-gradle-plugin/src/main/java/com/fizzed/rocker/gradle/RockerConfiguration.java
+++ b/rocker-gradle-plugin/src/main/java/com/fizzed/rocker/gradle/RockerConfiguration.java
@@ -156,6 +156,11 @@ public class RockerConfiguration {
     }
 
     @Input // Neither input nor output directory, but generated rocker.conf depends on it
+    public String getClassBaseDirectoryPath() {
+        return classBaseDirectory.getAbsolutePath();
+    }
+
+    @Internal
     public File getClassBaseDirectory() {
         return classBaseDirectory;
     }


### PR DESCRIPTION
This implements the changes suggested in #143. The behaviour is not changed but the Gradle plugin is now compatible with Gradle 7. 