### PR TITLE
Upgrade Antlr to the latest (4.11.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <main.java.package />
         <slf4j.version>1.7.7</slf4j.version>
-        <antlr.version>4.5.3</antlr.version>
+        <antlr.version>4.11.1</antlr.version>
         <java.version>1.7</java.version>
         <license.skip>true</license.skip>
         <!-- netbeans specific -->

--- a/rocker-compiler/src/test/java/com/fizzed/rocker/model/WithStatementTest.java
+++ b/rocker-compiler/src/test/java/com/fizzed/rocker/model/WithStatementTest.java
@@ -76,7 +76,7 @@ public class WithStatementTest {
             fail("Expected exception");
         }
         catch(ParserException e) {
-            assertThat(e.getMessage(), containsString("template-path:[1,18] missing ARGUMENT at '<EOF>'"));
+            assertThat(e.getMessage(), containsString("template-path:[1,18] extraneous input"));
         }
     }
 


### PR DESCRIPTION
In our project which uses rocker, one of our other dependencies pulls in a later version of Antlr than the 4.5.3 used in Rocker.

It used to pull in 4.8-1 and everything still worked, but since the move to 4.11.1, the Rocker code generation fails with errors such as

```
> java.io.InvalidClassException: org.antlr.v4.runtime.atn.ATN; Could not deserialize ATN with version 3 (expected 4).
  > org.antlr.v4.runtime.atn.ATN; Could not deserialize ATN with version 3 (expected 4).
```

This PR updates the antlr version to 4.11.1, and fixes the one error message that has changed in tests.

I cannot currently get the gradle-plugin module to build, but I'm not sure if this was caused by me 🤔